### PR TITLE
add an `add_claimed` operation to `out` command

### DIFF
--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -57,7 +57,7 @@ func main() {
 
 	if request.Params.Add != "" {
 		lockPath := filepath.Join(sourceDir, request.Params.Add)
-		lock, version, err = lockPool.AddLock(lockPath)
+		lock, version, err = lockPool.AddUnclaimedLock(lockPath)
 		if err != nil {
 			fatal("adding lock", err)
 		}
@@ -65,7 +65,7 @@ func main() {
 
 	if request.Params.AddClaimed != "" {
 		lockPath := filepath.Join(sourceDir, request.Params.AddClaimed)
-		lock, version, err = lockPool.AddLock(lockPath)                   // FIXME!!!!!
+		lock, version, err = lockPool.AddClaimedLock(lockPath)
 		if err != nil {
 			fatal("adding pre-claimed lock", err)
 		}

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -63,6 +63,14 @@ func main() {
 		}
 	}
 
+	if request.Params.AddClaimed != "" {
+		lockPath := filepath.Join(sourceDir, request.Params.AddClaimed)
+		lock, version, err = lockPool.AddLock(lockPath)                   // FIXME!!!!!
+		if err != nil {
+			fatal("adding pre-claimed lock", err)
+		}
+	}
+
 	if request.Params.Remove != "" {
 		removePath := filepath.Join(sourceDir, request.Params.Remove)
 		lock, version, err = lockPool.RemoveLock(removePath)
@@ -115,6 +123,7 @@ func validateRequest(request out.OutRequest) {
 	if request.Params.Acquire == false &&
 		request.Params.Release == "" &&
 		request.Params.Add == "" &&
+		request.Params.AddClaimed == "" &&
 		request.Params.Remove == "" &&
 		request.Params.Claim == "" {
 		errorMessages = append(errorMessages, "invalid payload (missing acquire, release, remove, claim, or add)")

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -126,7 +126,7 @@ func validateRequest(request out.OutRequest) {
 		request.Params.AddClaimed == "" &&
 		request.Params.Remove == "" &&
 		request.Params.Claim == "" {
-		errorMessages = append(errorMessages, "invalid payload (missing acquire, release, remove, claim, or add)")
+		errorMessages = append(errorMessages, "invalid payload (missing acquire, release, remove, claim, add, or add_claimed)")
 	}
 
 	if len(errorMessages) > 0 {

--- a/integration/out_test.go
+++ b/integration/out_test.go
@@ -133,7 +133,7 @@ func itWorksWithBranch(branchName string) {
 				It("complains about it", func() {
 					errorMessages := string(session.Err.Contents())
 
-					Ω(errorMessages).Should(ContainSubstring("invalid payload (missing acquire, release, remove, claim, or add)"))
+					Ω(errorMessages).Should(ContainSubstring("invalid payload (missing acquire, release, remove, claim, add, or add_claimed)"))
 				})
 			})
 		})

--- a/integration/out_test.go
+++ b/integration/out_test.go
@@ -627,7 +627,7 @@ func itWorksWithBranch(branchName string) {
 			})
 		})
 
-		Context("when adding a lock to the pool", func() {
+		Context("when adding an initially unclaimed lock to the pool", func() {
 			var lockToAddDir string
 			var cloneDir string
 
@@ -674,7 +674,7 @@ func itWorksWithBranch(branchName string) {
 				Ω(err).ShouldNot(HaveOccurred())
 			})
 
-			It("adds the new lock", func() {
+			It("adds the new lock in an unclaimed state", func() {
 				clone := exec.Command("git", "clone", "--branch", branchName, bareGitRepo, ".")
 				clone.Dir = cloneDir
 				err := clone.Run()
@@ -698,12 +698,11 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("pipeline-name/job-name #42 adding: " + outResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("pipeline-name/job-name #42 adding unclaimed: " + outResponse.Metadata[0].Value))
 			})
 		})
 
-
-		XContext("when adding a pre-claiming lock", func() {
+		Context("when adding an initially claimed lock to the pool", func() {
 			var lockToAddDir string
 			var cloneDir string
 
@@ -750,7 +749,7 @@ func itWorksWithBranch(branchName string) {
 				Ω(err).ShouldNot(HaveOccurred())
 			})
 
-			It("adds the new claimed lock", func() {
+			It("adds the new lock in a claimed state", func() {
 				clone := exec.Command("git", "clone", "--branch", branchName, bareGitRepo, ".")
 				clone.Dir = cloneDir
 				err := clone.Run()
@@ -774,10 +773,9 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("pipeline-name/job-name #42 adding and claiming: " + outResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("pipeline-name/job-name #42 adding claimed: " + outResponse.Metadata[0].Value))
 			})
 		})
-
 
 		Context("when 2 processes are acquiring a lock at the same time", func() {
 			var sessionOne *gexec.Session

--- a/out/fakes/fake_lock_handler.go
+++ b/out/fakes/fake_lock_handler.go
@@ -11,7 +11,7 @@ type FakeLockHandler struct {
 	GrabAvailableLockStub        func() (lock string, version string, err error)
 	grabAvailableLockMutex       sync.RWMutex
 	grabAvailableLockArgsForCall []struct{}
-	grabAvailableLockReturns     struct {
+	grabAvailableLockReturns struct {
 		result1 string
 		result2 string
 		result3 error
@@ -25,13 +25,13 @@ type FakeLockHandler struct {
 		result1 string
 		result2 error
 	}
-	AddLockStub        func(lock string, contents []byte) (version string, err error)
-	addLockMutex       sync.RWMutex
-	addLockArgsForCall []struct {
+	AddUnclaimedLockStub        func(lock string, contents []byte) (version string, err error)
+	addUnclaimedLockMutex       sync.RWMutex
+	addUnclaimedLockArgsForCall []struct {
 		lock     string
 		contents []byte
 	}
-	addLockReturns struct {
+	addUnclaimedLockReturns struct {
 		result1 string
 		result2 error
 	}
@@ -56,20 +56,20 @@ type FakeLockHandler struct {
 	SetupStub        func() error
 	setupMutex       sync.RWMutex
 	setupArgsForCall []struct{}
-	setupReturns     struct {
+	setupReturns struct {
 		result1 error
 	}
 	BroadcastLockPoolStub        func() ([]byte, error)
 	broadcastLockPoolMutex       sync.RWMutex
 	broadcastLockPoolArgsForCall []struct{}
-	broadcastLockPoolReturns     struct {
+	broadcastLockPoolReturns struct {
 		result1 []byte
 		result2 error
 	}
 	ResetLockStub        func() error
 	resetLockMutex       sync.RWMutex
 	resetLockArgsForCall []struct{}
-	resetLockReturns     struct {
+	resetLockReturns struct {
 		result1 error
 	}
 }
@@ -133,35 +133,35 @@ func (fake *FakeLockHandler) UnclaimLockReturns(result1 string, result2 error) {
 	}{result1, result2}
 }
 
-func (fake *FakeLockHandler) AddLock(lock string, contents []byte) (version string, err error) {
-	fake.addLockMutex.Lock()
-	fake.addLockArgsForCall = append(fake.addLockArgsForCall, struct {
+func (fake *FakeLockHandler) AddUnclaimedLock(lock string, contents []byte) (version string, err error) {
+	fake.addUnclaimedLockMutex.Lock()
+	fake.addUnclaimedLockArgsForCall = append(fake.addUnclaimedLockArgsForCall, struct {
 		lock     string
 		contents []byte
 	}{lock, contents})
-	fake.addLockMutex.Unlock()
-	if fake.AddLockStub != nil {
-		return fake.AddLockStub(lock, contents)
+	fake.addUnclaimedLockMutex.Unlock()
+	if fake.AddUnclaimedLockStub != nil {
+		return fake.AddUnclaimedLockStub(lock, contents)
 	} else {
-		return fake.addLockReturns.result1, fake.addLockReturns.result2
+		return fake.addUnclaimedLockReturns.result1, fake.addUnclaimedLockReturns.result2
 	}
 }
 
-func (fake *FakeLockHandler) AddLockCallCount() int {
-	fake.addLockMutex.RLock()
-	defer fake.addLockMutex.RUnlock()
-	return len(fake.addLockArgsForCall)
+func (fake *FakeLockHandler) AddUnclaimedLockCallCount() int {
+	fake.addUnclaimedLockMutex.RLock()
+	defer fake.addUnclaimedLockMutex.RUnlock()
+	return len(fake.addUnclaimedLockArgsForCall)
 }
 
-func (fake *FakeLockHandler) AddLockArgsForCall(i int) (string, []byte) {
-	fake.addLockMutex.RLock()
-	defer fake.addLockMutex.RUnlock()
-	return fake.addLockArgsForCall[i].lock, fake.addLockArgsForCall[i].contents
+func (fake *FakeLockHandler) AddUnclaimedLockArgsForCall(i int) (string, []byte) {
+	fake.addUnclaimedLockMutex.RLock()
+	defer fake.addUnclaimedLockMutex.RUnlock()
+	return fake.addUnclaimedLockArgsForCall[i].lock, fake.addUnclaimedLockArgsForCall[i].contents
 }
 
-func (fake *FakeLockHandler) AddLockReturns(result1 string, result2 error) {
-	fake.AddLockStub = nil
-	fake.addLockReturns = struct {
+func (fake *FakeLockHandler) AddUnclaimedLockReturns(result1 string, result2 error) {
+	fake.AddUnclaimedLockStub = nil
+	fake.addUnclaimedLockReturns = struct {
 		result1 string
 		result2 error
 	}{result1, result2}

--- a/out/fakes/fake_lock_handler.go
+++ b/out/fakes/fake_lock_handler.go
@@ -25,13 +25,14 @@ type FakeLockHandler struct {
 		result1 string
 		result2 error
 	}
-	AddUnclaimedLockStub        func(lock string, contents []byte) (version string, err error)
-	addUnclaimedLockMutex       sync.RWMutex
-	addUnclaimedLockArgsForCall []struct {
-		lock     string
-		contents []byte
+	AddLockStub        func(lock string, contents []byte, initiallyClaimed bool) (version string, err error)
+	addLockMutex       sync.RWMutex
+	addLockArgsForCall []struct {
+		lock             string
+		contents         []byte
+		initiallyClaimed bool
 	}
-	addUnclaimedLockReturns struct {
+	addLockReturns struct {
 		result1 string
 		result2 error
 	}
@@ -133,35 +134,36 @@ func (fake *FakeLockHandler) UnclaimLockReturns(result1 string, result2 error) {
 	}{result1, result2}
 }
 
-func (fake *FakeLockHandler) AddUnclaimedLock(lock string, contents []byte) (version string, err error) {
-	fake.addUnclaimedLockMutex.Lock()
-	fake.addUnclaimedLockArgsForCall = append(fake.addUnclaimedLockArgsForCall, struct {
-		lock     string
-		contents []byte
-	}{lock, contents})
-	fake.addUnclaimedLockMutex.Unlock()
-	if fake.AddUnclaimedLockStub != nil {
-		return fake.AddUnclaimedLockStub(lock, contents)
+func (fake *FakeLockHandler) AddLock(lock string, contents []byte, initiallyClaimed bool) (version string, err error) {
+	fake.addLockMutex.Lock()
+	fake.addLockArgsForCall = append(fake.addLockArgsForCall, struct {
+		lock             string
+		contents         []byte
+		initiallyClaimed bool
+	}{lock, contents, initiallyClaimed})
+	fake.addLockMutex.Unlock()
+	if fake.AddLockStub != nil {
+		return fake.AddLockStub(lock, contents, initiallyClaimed)
 	} else {
-		return fake.addUnclaimedLockReturns.result1, fake.addUnclaimedLockReturns.result2
+		return fake.addLockReturns.result1, fake.addLockReturns.result2
 	}
 }
 
-func (fake *FakeLockHandler) AddUnclaimedLockCallCount() int {
-	fake.addUnclaimedLockMutex.RLock()
-	defer fake.addUnclaimedLockMutex.RUnlock()
-	return len(fake.addUnclaimedLockArgsForCall)
+func (fake *FakeLockHandler) AddLockCallCount() int {
+	fake.addLockMutex.RLock()
+	defer fake.addLockMutex.RUnlock()
+	return len(fake.addLockArgsForCall)
 }
 
-func (fake *FakeLockHandler) AddUnclaimedLockArgsForCall(i int) (string, []byte) {
-	fake.addUnclaimedLockMutex.RLock()
-	defer fake.addUnclaimedLockMutex.RUnlock()
-	return fake.addUnclaimedLockArgsForCall[i].lock, fake.addUnclaimedLockArgsForCall[i].contents
+func (fake *FakeLockHandler) AddLockArgsForCall(i int) (string, []byte, bool) {
+	fake.addLockMutex.RLock()
+	defer fake.addLockMutex.RUnlock()
+	return fake.addLockArgsForCall[i].lock, fake.addLockArgsForCall[i].contents, fake.addLockArgsForCall[i].initiallyClaimed
 }
 
-func (fake *FakeLockHandler) AddUnclaimedLockReturns(result1 string, result2 error) {
-	fake.AddUnclaimedLockStub = nil
-	fake.addUnclaimedLockReturns = struct {
+func (fake *FakeLockHandler) AddLockReturns(result1 string, result2 error) {
+	fake.AddLockStub = nil
+	fake.addLockReturns = struct {
 		result1 string
 		result2 error
 	}{result1, result2}

--- a/out/git_lock_handler.go
+++ b/out/git_lock_handler.go
@@ -111,9 +111,16 @@ func (glh *GitLockHandler) ResetLock() error {
 	return nil
 }
 
-func (glh *GitLockHandler) AddUnclaimedLock(lock string, contents []byte) (string, error) {
+func (glh *GitLockHandler) AddLock(lock string, contents []byte, initiallyClaimed bool) (string, error) {
+	var claimedness string
+	if initiallyClaimed {
+		claimedness = "claimed"
+	} else {
+		claimedness = "unclaimed"
+	}
+
 	pool := filepath.Join(glh.dir, glh.Source.Pool)
-	lockPath := filepath.Join(pool, "unclaimed", lock)
+	lockPath := filepath.Join(pool, claimedness, lock)
 
 	err := ioutil.WriteFile(lockPath, contents, 0555)
 	if err != nil {
@@ -125,7 +132,8 @@ func (glh *GitLockHandler) AddUnclaimedLock(lock string, contents []byte) (strin
 		return "", err
 	}
 
-	_, err = glh.git("commit", lockPath, "-m", glh.messagePrefix()+fmt.Sprintf("adding: %s", lock))
+	commitMessage := glh.messagePrefix() + fmt.Sprintf("adding %s: %s", claimedness, lock)
+	_, err = glh.git("commit", lockPath, "-m", commitMessage)
 	if err != nil {
 		return "", err
 	}

--- a/out/git_lock_handler.go
+++ b/out/git_lock_handler.go
@@ -111,7 +111,7 @@ func (glh *GitLockHandler) ResetLock() error {
 	return nil
 }
 
-func (glh *GitLockHandler) AddLock(lock string, contents []byte) (string, error) {
+func (glh *GitLockHandler) AddUnclaimedLock(lock string, contents []byte) (string, error) {
 	pool := filepath.Join(glh.dir, glh.Source.Pool)
 	lockPath := filepath.Join(pool, "unclaimed", lock)
 

--- a/out/lock_pool.go
+++ b/out/lock_pool.go
@@ -33,7 +33,7 @@ func NewLockPool(source Source, output io.Writer) LockPool {
 type LockHandler interface {
 	GrabAvailableLock() (lock string, version string, err error)
 	UnclaimLock(lock string) (version string, err error)
-	AddUnclaimedLock(lock string, contents []byte) (version string, err error)
+	AddLock(lock string, contents []byte, initiallyClaimed bool) (version string, err error)
 	RemoveLock(lock string) (version string, err error)
 	ClaimLock(lock string) (version string, err error)
 
@@ -133,7 +133,15 @@ func (lp *LockPool) ReleaseLock(inDir string) (string, Version, error) {
 	}, nil
 }
 
-func (lp *LockPool) AddLock(inDir string) (string, Version, error) {
+func (lp *LockPool) AddClaimedLock(inDir string) (string, Version, error) {
+	return lp.addLock(inDir, true)
+}
+
+func (lp *LockPool) AddUnclaimedLock(inDir string) (string, Version, error) {
+	return lp.addLock(inDir, false)
+}
+
+func (lp *LockPool) addLock(inDir string, initiallyClaimed bool) (string, Version, error) {
 	nameFileContents, err := ioutil.ReadFile(filepath.Join(inDir, "name"))
 	if err != nil {
 		return "", Version{}, fmt.Errorf("could not read the name file of your lock: %s", err)
@@ -145,13 +153,17 @@ func (lp *LockPool) AddLock(inDir string) (string, Version, error) {
 		return "", Version{}, fmt.Errorf("could not read the metadata file of your lock: %s", err)
 	}
 
-	fmt.Fprintf(lp.Output, "adding lock: %s to pool: %s\n", lockName, lp.Source.Pool)
+	if initiallyClaimed {
+		fmt.Fprintf(lp.Output, "adding claimed lock: %s to pool: %s\n", lockName, lp.Source.Pool)
+	} else {
+		fmt.Fprintf(lp.Output, "adding unclaimed lock: %s to pool: %s\n", lockName, lp.Source.Pool)
+	}
 
 	var ref string
 
 	err = lp.performRobustAction(func() (bool, error) {
 		var err error
-		ref, err = lp.LockHandler.AddUnclaimedLock(lockName, lockContents)
+		ref, err = lp.LockHandler.AddLock(lockName, lockContents, initiallyClaimed)
 
 		if err != nil {
 			fmt.Fprintf(lp.Output, "failed to add the lock: %s! (err: %s) retrying...\n", lockName, err)

--- a/out/lock_pool.go
+++ b/out/lock_pool.go
@@ -33,7 +33,7 @@ func NewLockPool(source Source, output io.Writer) LockPool {
 type LockHandler interface {
 	GrabAvailableLock() (lock string, version string, err error)
 	UnclaimLock(lock string) (version string, err error)
-	AddLock(lock string, contents []byte) (version string, err error)
+	AddUnclaimedLock(lock string, contents []byte) (version string, err error)
 	RemoveLock(lock string) (version string, err error)
 	ClaimLock(lock string) (version string, err error)
 
@@ -151,7 +151,7 @@ func (lp *LockPool) AddLock(inDir string) (string, Version, error) {
 
 	err = lp.performRobustAction(func() (bool, error) {
 		var err error
-		ref, err = lp.LockHandler.AddLock(lockName, lockContents)
+		ref, err = lp.LockHandler.AddUnclaimedLock(lockName, lockContents)
 
 		if err != nil {
 			fmt.Fprintf(lp.Output, "failed to add the lock: %s! (err: %s) retrying...\n", lockName, err)

--- a/out/lock_pool_test.go
+++ b/out/lock_pool_test.go
@@ -739,8 +739,8 @@ var _ = Describe("Lock Pool", func() {
 					_, _, err := lockPool.AddLock(lockDir)
 					Ω(err).ShouldNot(HaveOccurred())
 
-					Ω(fakeLockHandler.AddLockCallCount()).Should(Equal(1))
-					lockName, lockContents := fakeLockHandler.AddLockArgsForCall(0)
+					Ω(fakeLockHandler.AddUnclaimedLockCallCount()).Should(Equal(1))
+					lockName, lockContents := fakeLockHandler.AddUnclaimedLockArgsForCall(0)
 					Ω(lockName).Should(Equal("some-lock"))
 					Ω(string(lockContents)).Should(Equal("lock-contents"))
 				})
@@ -749,7 +749,7 @@ var _ = Describe("Lock Pool", func() {
 					BeforeEach(func() {
 						called := false
 
-						fakeLockHandler.AddLockStub = func(lockName string, lockContents []byte) (string, error) {
+						fakeLockHandler.AddUnclaimedLockStub = func(lockName string, lockContents []byte) (string, error) {
 							// succeed on second call
 							if !called {
 								called = true
@@ -764,13 +764,13 @@ var _ = Describe("Lock Pool", func() {
 						_, _, err := lockPool.AddLock(lockDir)
 						Ω(err).ShouldNot(HaveOccurred())
 
-						Ω(fakeLockHandler.AddLockCallCount()).Should(Equal(2))
+						Ω(fakeLockHandler.AddUnclaimedLockCallCount()).Should(Equal(2))
 					})
 				})
 
 				Context("when adding the lock succeeds", func() {
 					BeforeEach(func() {
-						fakeLockHandler.AddLockReturns("some-ref", nil)
+						fakeLockHandler.AddUnclaimedLockReturns("some-ref", nil)
 					})
 
 					It("tries to broadcast to the lock pool", func() {
@@ -803,7 +803,7 @@ var _ = Describe("Lock Pool", func() {
 								// no logging for expected errors
 								Ω(output).ShouldNot(gbytes.Say("err"))
 
-								Ω(fakeLockHandler.AddLockCallCount()).Should(Equal(2))
+								Ω(fakeLockHandler.AddUnclaimedLockCallCount()).Should(Equal(2))
 								Ω(fakeLockHandler.BroadcastLockPoolCallCount()).Should(Equal(2))
 							})
 						})
@@ -830,7 +830,7 @@ var _ = Describe("Lock Pool", func() {
 								// no logging for expected errors
 								Ω(output).Should(gbytes.Say("err"))
 
-								Ω(fakeLockHandler.AddLockCallCount()).Should(Equal(2))
+								Ω(fakeLockHandler.AddUnclaimedLockCallCount()).Should(Equal(2))
 								Ω(fakeLockHandler.BroadcastLockPoolCallCount()).Should(Equal(2))
 							})
 
@@ -846,7 +846,7 @@ var _ = Describe("Lock Pool", func() {
 									Ω(output).Should(gbytes.Say("some git message"))
 
 									Ω(fakeLockHandler.ResetLockCallCount()).Should(Equal(5))
-									Ω(fakeLockHandler.AddLockCallCount()).Should(Equal(5))
+									Ω(fakeLockHandler.AddUnclaimedLockCallCount()).Should(Equal(5))
 									Ω(fakeLockHandler.BroadcastLockPoolCallCount()).Should(Equal(5))
 								})
 							})

--- a/out/models.go
+++ b/out/models.go
@@ -15,11 +15,12 @@ type Version struct {
 }
 
 type OutParams struct {
-	Release string `json:"release"`
-	Acquire bool   `json:"acquire"`
-	Add     string `json:"add"`
-	Remove  string `json:"remove"`
-	Claim   string `json:"claim"`
+	Release     string `json:"release"`
+	Acquire     bool   `json:"acquire"`
+	Add         string `json:"add"`
+	AddClaimed  string `json:"add_claimed"`
+	Remove      string `json:"remove"`
+	Claim       string `json:"claim"`
 }
 
 type OutRequest struct {


### PR DESCRIPTION
This `add_claimed` operation will add a new lock to the pool just as `add` does, but rather than initially placing the lock in an unclaimed state it will be placed in a claimed state.