### PR TITLE
File modifications in-place don't break locks

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -19,7 +19,7 @@ check_if_file_changed_in_range() {
   local start=$2
   local end=$3
 
-  if [ -n "$(git log --oneline $start..$end -- "$filepath")" ]; then
+  if [ -n "$(git log --oneline --diff-filter=ACDRTUXB $start..$end -- "$filepath")" ]; then
     echo "error: lock instance is no longer acquired"
     exit 1
   fi

--- a/integration/in_test.go
+++ b/integration/in_test.go
@@ -244,7 +244,54 @@ var _ = Describe("In", func() {
 					})
 				})
 			})
+			Context("when the given commit claimed the lock and the file was modified in place afterwards", func() {
+				BeforeEach(func() {
+					var err error
+					gitVersion := exec.Command("git", "rev-parse", "HEAD")
+					gitVersion.Dir = gitRepo
+					sha, err := gitVersion.Output()
+					Ω(err).ShouldNot(HaveOccurred())
+					shaStr = strings.TrimSpace(string(sha))
 
+					changeFile := exec.Command("bash", "-e", "-c", `
+					echo "additional_key: additional_value" >> lock-pool/claimed/some-lock
+					  git add lock-pool/claimed/some-lock
+					  git commit -m 'changing: some-lock'
+					`)
+					changeFile.Dir = gitRepo
+
+					err = changeFile.Run()
+					Ω(err).ShouldNot(HaveOccurred())
+				})
+
+				It("returns successfully", func() {
+					jsonIn := fmt.Sprintf(`
+						{
+							"source": {
+								"uri": "%s",
+								"branch": "master",
+								"pool": "lock-pool"
+							},
+							"version": {
+								"ref": "%s"
+							}
+						}`, gitRepo, shaStr)
+
+					session := runIn(jsonIn, inDestination, 0)
+
+					err := json.Unmarshal(session.Out.Contents(), &output)
+					Ω(err).ShouldNot(HaveOccurred())
+					Ω(output).Should(Equal(inResponse{
+						Version: version{
+							Ref: shaStr,
+						},
+						Metadata: []metadataPair{
+							{Name: "lock_name", Value: "some-lock"},
+							{Name: "pool_name", Value: "lock-pool"},
+						},
+					}))
+				})
+			})
 			Context("when the commit itself unclaimed the lock", func() {
 				var shaStr string
 				BeforeEach(func() {


### PR DESCRIPTION
Hi concourse,

To allow batch changes of environment files without affecting in-flight pipelines, we made a small change to `assets/in` to tolerate modified pool resources which haven't otherwise been moved. We tested this on releng's concourse deployment, and saw that a pipeline continued to hold the lock after we had modified an environment file. We also verified that moving an environment file would still result in a broken lock. We did notice that, in the latter case, that it took 2 pipeline jobs for the lock to break because of resource caching.

It should also be noted that, since the pool resource uses the commit sha from the original lock acquisition, the changes to the environment will not be reflected until the environment has been released and re-acquired.

Let us know if you have any questions about our testing or changes.

Raina Masand and Dave Walter
CF Release Engineering