### PR TITLE
Change update help if ginkgo is not installed

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -14,7 +14,7 @@ pool_resource_dir=$(cd $(dirname $0)/.. && pwd)
 
 if not_installed ginkgo; then
   echo "# ginkgo is not installed! run the following command:"
-  echo "    go install github.com/onsi/ginkgo/ginkgo"
+  echo "    go get github.com/onsi/ginkgo/ginkgo"
   exit 1
 fi
 


### PR DESCRIPTION
I think `go install` only works if the package has already been downloaded, `go get` will go download and install it.  I'm a go novice, so please feel free to correct me.