### PR TITLE
username and password auth for HTTP(S) added

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ This structure represents 3 pools of locks, `aws`, `ping-pong-tables`, and
       -----END RSA PRIVATE KEY-----
     ```
 
+* `username`: *Optional.* Username for HTTP(S) auth when pulling/pushing.
+  This is needed when only HTTP/HTTPS protocol for git is available (which does not support private key auth) and auth is required.
+
+* `password`: *Optional.* Password for HTTP(S) auth when pulling/pushing.
+
 * `retry_delay`: *Optional.* If specified, dictates how long to wait until
   retrying to acquire a lock or release a lock. The default is 10 seconds.
   Valid values: `60s`, `90m`, `1h`.

--- a/assets/check
+++ b/assets/check
@@ -16,6 +16,7 @@ payload=$TMPDIR/git-resource-request
 cat > $payload <&0
 
 load_pubkey $payload
+configure_credentials $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -21,3 +21,12 @@ EOF
     chmod 0600 ~/.ssh/config
   fi
 }
+
+configure_credentials() {
+  local username=$(jq -r '.source.username // ""' < $1)
+  local password=$(jq -r '.source.password // ""' < $1)
+
+  if [ "$username" != "" -a "$password" != "" ]; then
+    echo "default login $username password $password" > $HOME/.netrc
+  fi
+}

--- a/assets/in
+++ b/assets/in
@@ -33,6 +33,7 @@ payload=$(mktemp $TMPDIR/pool-resource-request.XXXXXX)
 cat > $payload <&0
 
 load_pubkey $payload
+configure_credentials $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)

--- a/assets/out
+++ b/assets/out
@@ -10,5 +10,6 @@ exec 1>&2 # redirect all output to stderr for logging
 payload=$(mktemp $TMPDIR/pool-resource-request.XXXXXX)
 cat > $payload <&0
 load_pubkey $payload
+configure_credentials $payload
 
 /opt/go/out $1 >&3 < $payload

--- a/ci/build
+++ b/ci/build
@@ -4,12 +4,12 @@
 set -e -u -x
 
 export TMPDIR=/tmp
-export GOPATH=$PWD/gopath
+#export GOPATH=$PWD/gopath
 export PATH=$GOPATH/bin:$PATH
 
 BUILD_DIR=$PWD/built-resource
 
-cd $GOPATH/src/github.com/concourse/pool-resource
+#cd $GOPATH/src/github.com/concourse/pool-resource
 
 export GOPATH=${PWD}/Godeps/_workspace:$GOPATH
 export PATH=${PWD}/Godeps/_workspace/bin:$PATH

--- a/test/check.sh
+++ b/test/check.sh
@@ -101,9 +101,24 @@ it_can_check_when_not_ff() {
   "
 }
 
+it_can_check_with_credentials() {
+  local repo=$(init_repo)
+  local ref=$(make_commit_to_file $repo my_pool/unclaimed/file-a)
+
+  check_uri_with_credentials $repo "user1" "pass1" | jq -e "
+    . == [{ref: $(echo $ref | jq -R .)}]
+  "
+
+  # only check that the expected credential helper is set
+  # because it is not easily possible to simulate a git http backend that needs credentials
+  local expected_netrc="default login user1 password pass1"
+  [ "$(cat $HOME/.netrc)" = "$expected_netrc" ]
+}
+
 
 run it_can_check_from_head
 run it_can_check_from_a_ref
 run it_can_check_from_a_bogus_sha
 run it_checks_given_pool
 run it_can_check_when_not_ff
+run it_can_check_with_credentials

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -162,3 +162,15 @@ check_uri_from_paths() {
     }
   }" | ${resource_dir}/check | tee /dev/stderr
 }
+
+check_uri_with_credentials() {
+  jq -n "{
+    source: {
+      uri: $(echo $1 | jq -R .),
+      branch: \"master\",
+      pool: \"my_pool\",
+      username: $(echo $2 | jq -R .),
+      password: $(echo $3 | jq -R .)
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}


### PR DESCRIPTION
We're sitting behind a corporate firewall that only allows HTTPS access to our git repositories.
In such scenarios, public key - which is only possible using ssh - is not possible and username and password auth needs to be used.

This PR introduces two options, username and password which can be used for authenticating with HTTP(S).

Related to concourse/git-resource#44