### PR TITLE
"Escaping" buildId and buildName so github doesn't link them to existing …

### DIFF
--- a/integration/out_test.go
+++ b/integration/out_test.go
@@ -203,7 +203,7 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("pipeline-name/job-name #42 claiming: " + outResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("pipeline-name/job-name `#42` claiming: " + outResponse.Metadata[0].Value))
 			})
 		})
 
@@ -341,7 +341,7 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("pipeline-name/job-name #42 claiming: some-lock"))
+				Ω(session).Should(gbytes.Say("pipeline-name/job-name `#42` claiming: some-lock"))
 			})
 
 			Context("when the specific lock has already been claimed", func() {
@@ -504,7 +504,7 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("pipeline-name/job-name #42 removing: " + outRemoveResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("pipeline-name/job-name `#42` removing: " + outRemoveResponse.Metadata[0].Value))
 			})
 		})
 
@@ -623,7 +623,7 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("pipeline-name/job-name #42 unclaiming: " + outReleaseResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("pipeline-name/job-name `#42` unclaiming: " + outReleaseResponse.Metadata[0].Value))
 			})
 		})
 
@@ -698,7 +698,7 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("pipeline-name/job-name #42 adding unclaimed: " + outResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("pipeline-name/job-name `#42` adding unclaimed: " + outResponse.Metadata[0].Value))
 			})
 		})
 
@@ -773,7 +773,7 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("pipeline-name/job-name #42 adding claimed: " + outResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("pipeline-name/job-name `#42` adding claimed: " + outResponse.Metadata[0].Value))
 			})
 		})
 

--- a/out/git_lock_handler.go
+++ b/out/git_lock_handler.go
@@ -249,9 +249,9 @@ func (glh *GitLockHandler) messagePrefix() string {
 	pipelineName := os.Getenv("BUILD_PIPELINE_NAME")
 
 	if buildName != "" && jobName != "" && pipelineName != "" {
-		return fmt.Sprintf("%s/%s #%s ", pipelineName, jobName, buildName)
+		return fmt.Sprintf("%s/%s `#%s` ", pipelineName, jobName, buildName)
 	} else if buildID != "" {
-		return fmt.Sprintf("one-off #%s ", buildID)
+		return fmt.Sprintf("one-off `#%s` ", buildID)
 	}
 
 	return ""


### PR DESCRIPTION
…issues or pull requests.

See [this PR for more an example](https://github.com/cloudfoundry/buildpacks-ci/pull/3)