### PR TITLE
Revert tolerance of in-place file modifications

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -19,7 +19,7 @@ check_if_file_changed_in_range() {
   local start=$2
   local end=$3
 
-  if [ -n "$(git log --oneline --diff-filter=ACDRTUXB $start..$end -- "$filepath")" ]; then
+  if [ -n "$(git log --oneline $start..$end -- "$filepath")" ]; then
     echo "error: lock instance is no longer acquired"
     exit 1
   fi

--- a/integration/in_test.go
+++ b/integration/in_test.go
@@ -244,54 +244,7 @@ var _ = Describe("In", func() {
 					})
 				})
 			})
-			Context("when the given commit claimed the lock and the file was modified in place afterwards", func() {
-				BeforeEach(func() {
-					var err error
-					gitVersion := exec.Command("git", "rev-parse", "HEAD")
-					gitVersion.Dir = gitRepo
-					sha, err := gitVersion.Output()
-					Ω(err).ShouldNot(HaveOccurred())
-					shaStr = strings.TrimSpace(string(sha))
 
-					changeFile := exec.Command("bash", "-e", "-c", `
-					echo "additional_key: additional_value" >> lock-pool/claimed/some-lock
-					  git add lock-pool/claimed/some-lock
-					  git commit -m 'changing: some-lock'
-					`)
-					changeFile.Dir = gitRepo
-
-					err = changeFile.Run()
-					Ω(err).ShouldNot(HaveOccurred())
-				})
-
-				It("returns successfully", func() {
-					jsonIn := fmt.Sprintf(`
-						{
-							"source": {
-								"uri": "%s",
-								"branch": "master",
-								"pool": "lock-pool"
-							},
-							"version": {
-								"ref": "%s"
-							}
-						}`, gitRepo, shaStr)
-
-					session := runIn(jsonIn, inDestination, 0)
-
-					err := json.Unmarshal(session.Out.Contents(), &output)
-					Ω(err).ShouldNot(HaveOccurred())
-					Ω(output).Should(Equal(inResponse{
-						Version: version{
-							Ref: shaStr,
-						},
-						Metadata: []metadataPair{
-							{Name: "lock_name", Value: "some-lock"},
-							{Name: "pool_name", Value: "lock-pool"},
-						},
-					}))
-				})
-			})
 			Context("when the commit itself unclaimed the lock", func() {
 				var shaStr string
 				BeforeEach(func() {


### PR DESCRIPTION
Hello,

I'm coming to revert an accepted PR https://github.com/concourse/pool-resource/pull/11 that was made with the goal of allowing in-place modifications of lock files. My team keeps metadata in these files and sometimes needs to change them in batches, which is painful when we can't modify the contents of claimed locks.

After the initial PR was accepted, we realized that it didn't quite work as expected. We knew that the in-place modifications wouldn't be available immediately, but didn't realize how the unclaiming process works. The resource checks out the SHA from when it first claimed the lock and uses that version of the file to unclaim it. The few times we attempted to modify a locked file, the changes were simply reverted when it was unlocked. The intended flow couldn't be fully represented in the integration tests, so we didn't notice until we tried it manually.

We discussed changing the unclaim process to use the latest version of the file, but it seemed like it added complexity to the existing behavior and we still didn't know whether anyone else wanted this feature. In the end, my team decided that we'd prefer to store our metadata separately from the lock files, and therefore don't need this anymore. We'd like to revert our original changes, since the current behavior might be confusing if someone encountered it. Perhaps this work can be used in the future if the full feature is desired, but it seemed like a good idea to back everything out for now.

Thanks,
Raina Masand
PCF Release Engineering