### PR TITLE
Implement an atomic lock check action.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ One of the following is required.
   * If the lock is in the claimed state we will wait for it to be unclaimed and
     proceed to update it as above.
 
+* `check`: If set, we will check the lock status of a specified lock from the pool.
+  This is the atomic equivalent of performing a `claim` on that lock, followed
+  by a `release`. Like `claim`, will retry until the lock becomes available.
+  Note that this will, in fact, perform locking and unlocking operations, and will
+  produce new commits in the Git repository.
+
   The value is the path to a directory containing the files `name` and
   `metadata` which should contain the name of your new lock and the contents you
   would like in the lock, respectively.

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -102,6 +102,18 @@ func main() {
 		}
 	}
 
+	if request.Params.Check != "" {
+		lock = request.Params.Check
+		version, err = lockPool.ClaimLock(lock)
+		if err != nil {
+			fatal("claiming lock for check", err)
+		}
+		_, version, err = lockPool.UnclaimLock(lock)
+		if err != nil {
+			fatal("unclaiming lock for check", err)
+		}
+	}
+
 	err = json.NewEncoder(os.Stdout).Encode(out.OutResponse{
 		Version: version,
 		Metadata: []out.MetadataPair{

--- a/out/lock_pool.go
+++ b/out/lock_pool.go
@@ -110,10 +110,14 @@ func (lp *LockPool) ReleaseLock(inDir string) (string, Version, error) {
 	}
 	lockName := strings.TrimSpace(string(nameFileContents))
 
+	return lp.UnclaimLock(lockName)
+}
+
+func (lp *LockPool) UnclaimLock(lockName string) (string, Version, error) {
 	fmt.Fprintf(lp.Output, "releasing lock: %s on pool: %s\n", lockName, lp.Source.Pool)
 
 	var ref string
-	err = lp.performRobustAction(func() (bool, error) {
+	err := lp.performRobustAction(func() (bool, error) {
 		var err error
 		ref, err = lp.LockHandler.UnclaimLock(lockName)
 

--- a/out/out_request.go
+++ b/out/out_request.go
@@ -54,6 +54,7 @@ type OutParams struct {
 	Remove     string `json:"remove"`
 	Claim      string `json:"claim"`
 	Update     string `json:"update"`
+	Check      string `json:"check"`
 }
 
 func (request OutRequest) Validate() []string {
@@ -77,8 +78,9 @@ func (request OutRequest) Validate() []string {
 		request.Params.AddClaimed == "" &&
 		request.Params.Remove == "" &&
 		request.Params.Claim == "" &&
-		request.Params.Update == "" {
-		errorMessages = append(errorMessages, "invalid payload (missing acquire, release, remove, claim, add, or add_claimed)")
+		request.Params.Update == "" &&
+		request.Params.Check == "" {
+		errorMessages = append(errorMessages, "invalid payload (missing acquire, release, remove, claim, check, add, or add_claimed)")
 	}
 
 	return errorMessages


### PR DESCRIPTION
Analogous to a hardware lock check, this will atomically try to acquire
a specified lock (and wait until it can), then immediately release the lock.

Co-authored-by: Rafay <rafay@autonomic.ai>