### PR TITLE
Add the team name to the commit log

### DIFF
--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -84,6 +84,7 @@ func runOut(request out.OutRequest, sourceDir string) *gexec.Session {
 		"BUILD_NAME=42",
 		"BUILD_JOB_NAME=job-name",
 		"BUILD_PIPELINE_NAME=pipeline-name",
+		"BUILD_TEAM_NAME=team-name",
 	)
 
 	stdin, err := outCmd.StdinPipe()

--- a/integration/out_test.go
+++ b/integration/out_test.go
@@ -204,7 +204,7 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("pipeline-name/job-name build 42 claiming: " + outResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("team-name/pipeline-name/job-name build 42 claiming: " + outResponse.Metadata[0].Value))
 			})
 		})
 
@@ -344,7 +344,7 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("pipeline-name/job-name build 42 claiming: some-lock"))
+				Ω(session).Should(gbytes.Say("team-name/pipeline-name/job-name build 42 claiming: some-lock"))
 			})
 
 			Context("when the specific lock has already been claimed", func() {
@@ -510,7 +510,7 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("pipeline-name/job-name build 42 removing: " + outRemoveResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("team-name/pipeline-name/job-name build 42 removing: " + outRemoveResponse.Metadata[0].Value))
 			})
 		})
 
@@ -631,7 +631,7 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("pipeline-name/job-name build 42 unclaiming: " + outReleaseResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("team-name/pipeline-name/job-name build 42 unclaiming: " + outReleaseResponse.Metadata[0].Value))
 			})
 		})
 
@@ -707,7 +707,7 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("pipeline-name/job-name build 42 adding unclaimed: " + outResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("team-name/pipeline-name/job-name build 42 adding unclaimed: " + outResponse.Metadata[0].Value))
 			})
 		})
 
@@ -783,7 +783,7 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("pipeline-name/job-name build 42 adding claimed: " + outResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("team-name/pipeline-name/job-name build 42 adding claimed: " + outResponse.Metadata[0].Value))
 			})
 		})
 
@@ -871,7 +871,7 @@ func itWorksWithBranch(branchName string) {
 
 					<-session.Exited
 
-					Ω(session).Should(gbytes.Say("pipeline-name/job-name build 42 adding unclaimed: " + outResponse.Metadata[0].Value))
+					Ω(session).Should(gbytes.Say("team-name/pipeline-name/job-name build 42 adding unclaimed: " + outResponse.Metadata[0].Value))
 				})
 			})
 
@@ -984,7 +984,7 @@ func itWorksWithBranch(branchName string) {
 
 					<-session.Exited
 
-					Ω(session).Should(gbytes.Say("pipeline-name/job-name build 42 updating: " + outResponse.Metadata[0].Value))
+					Ω(session).Should(gbytes.Say("team-name/pipeline-name/job-name build 42 updating: " + outResponse.Metadata[0].Value))
 				})
 			})
 		})

--- a/out/git_lock_handler.go
+++ b/out/git_lock_handler.go
@@ -292,9 +292,10 @@ func (glh *GitLockHandler) messagePrefix() string {
 	buildName := os.Getenv("BUILD_NAME")
 	jobName := os.Getenv("BUILD_JOB_NAME")
 	pipelineName := os.Getenv("BUILD_PIPELINE_NAME")
+	teamName := os.Getenv("BUILD_TEAM_NAME")
 
-	if buildName != "" && jobName != "" && pipelineName != "" {
-		return fmt.Sprintf("%s/%s build %s ", pipelineName, jobName, buildName)
+	if buildName != "" && jobName != "" && pipelineName != "" && teamName != "" {
+		return fmt.Sprintf("%s/%s/%s build %s ", teamName, pipelineName, jobName, buildName)
 	} else if buildID != "" {
 		return fmt.Sprintf("one-off build %s ", buildID)
 	}


### PR DESCRIPTION
As some fly operations are team specific, include the team name in the commit log so we have all the information we need to query concourse if needed.