### PR TITLE
add diff_filter param to source config [closing #47]

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,21 @@ filed named `.gitkeep`. Finally, create individual locks by making an empty file
   retrying to acquire a lock or release a lock. The default is 10 seconds.
   Valid values: `60s`, `90m`, `1h`.
 
+* `diff_filter`: *Optional.* If specified, changes the behavior of check. This is an advanced feature of git, refer
+  to [git-log](https://git-scm.com/docs/git-log#git-log---diff-filterACDMRTUXB82308203) for more information.
+  The default behavior is checking on every commit.
+
 
 ## Behavior
 
 ### `check`: Check for changes to the pool.
 
-The repository is cloned (or pulled if already present), and any commits made to the specified pool from the given version on are returned. If no version is
-given, the ref for `HEAD` is returned.
+The repository is cloned (or pulled if already present), and any commits made to the specified pool from the given version on are returned.
+If no version is given, the ref for `HEAD` is returned. The behavior can be altered by defining `diff_filter` in source
+configuration.
+
+For example, if only want to check whenever the resource is removed (deleted) from the pool, `diff_filter: D` can be
+set in the source configuration.
 
 
 ### `in`: Fetch an acquired lock.

--- a/README.md
+++ b/README.md
@@ -73,9 +73,8 @@ filed named `.gitkeep`. Finally, create individual locks by making an empty file
   Valid values: `60s`, `90m`, `1h`.
 
 * `diff_filter`: *Optional.* If specified, changes the behavior of check. This is an advanced feature of git, refer
-  to [git-log](https://git-scm.com/docs/git-log#git-log---diff-filterACDMRTUXB82308203) for more information.
+  to [git-log](https://git-scm.com/docs/git-log#Documentation/git-log.txt---diff-filterACDMRTUXB82308203) for more information.
   The default behavior is checking on every commit.
-
 
 ## Behavior
 
@@ -85,9 +84,16 @@ The repository is cloned (or pulled if already present), and any commits made to
 If no version is given, the ref for `HEAD` is returned. The behavior can be altered by defining `diff_filter` in source
 configuration.
 
-For example, if only want to check whenever the resource is removed (deleted) from the pool, `diff_filter: D` can be
-set in the source configuration.
+Here is a mapping between `diff-filter` and check behavior:
 
+| Diff-filter | Check Behavior          |
+|-------------|-------------------------|
+| A           | add, add_claimed        |
+| R           | acquire, claim, release |
+| D           | remove                  |
+| M           | update                  |
+
+For example, if `diff_filter: AM` is specificed, it will only check when a resource is added to the pool or the existing resource is updated.
 
 ### `in`: Fetch an acquired lock.
 

--- a/assets/check
+++ b/assets/check
@@ -21,6 +21,7 @@ configure_credentials $payload
 uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)
 pool_name=$(jq -r '.source.pool // ""' < $payload)
+diff_filter=$(jq -r '.source.diff_filter // ""' < $payload)
 ref=$(jq -r '.version.ref // ""' < $payload)
 
 
@@ -57,6 +58,10 @@ else
   cd $destination
 fi
 
+if [ -n "$diff_filter" ]; then
+  diff_filter="--diff-filter $diff_filter"
+fi
+
 {
   if [ -n "$ref" ] && git cat-file -e "$ref"; then
     init_commit=$(git rev-list --max-parents=0 HEAD)
@@ -69,6 +74,6 @@ fi
     log_range="-1"
   fi
 
-  git log $log_range --pretty='format:%H' -- $pool_name
+  git log $log_range $diff_filter --pretty='format:%H' -- $pool_name
 
  } | jq -R '.' | jq -s "map({ref: .})" >&3


### PR DESCRIPTION
#47 
expose `diff-filter` to alter the behavior of check directly. Feels adding something like `check_config` is going to introduce a level of unnecessary abstraction. 