### PR TITLE
Clones only the history leading to the tip of a single branch.

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -53,7 +53,7 @@ else
     branchflag="--branch $branch"
   fi
 
-  git clone $uri $branchflag $destination
+  git clone --single-branch $uri $branchflag $destination
   cd $destination
 fi
 

--- a/assets/in
+++ b/assets/in
@@ -62,7 +62,7 @@ if [ -n "$branch" ]; then
   branchflag="--branch $branch"
 fi
 
-git clone $uri $branchflag $destination
+git clone --single-branch $uri $branchflag $destination
 
 cd $destination
 


### PR DESCRIPTION
- This is consistent with the behavior of the git-resource.
- This speeds up cloning git repositories.

Authored-by: Maryam Labib <mlabib@pivotal.io>
Co-authored-by: Soumya GB <gowdabas@usc.edu>