### PR TITLE
Adds optional depth parameter for specifying the number of git commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ filed named `.gitkeep`. Finally, create individual locks by making an empty file
   retrying to acquire a lock or release a lock. The default is 10 seconds.
   Valid values: `60s`, `90m`, `1h`.
 
+### Example
+
+Fetching a repo with only 100 commits of history:
+
+``` yaml
+- get: source-code
+  params: {depth: 100}
+```
 
 ## Behavior
 
@@ -83,6 +91,7 @@ given, the ref for `HEAD` is returned.
 
 ### `in`: Fetch an acquired lock.
 
+
 Outputs 2 files:
 
 * `metadata`: Contains the contents of whatever was in your lock file. This is
@@ -90,6 +99,10 @@ Outputs 2 files:
 
 * `name`: Contains the name of lock that was acquired.
 
+#### Parameters
+
+* `depth`: *Optional.* If a positive integer is given, *shallow* clone the
+  repository using the `--depth` option.
 
 ### `out`: Acquire, release, add, or remove a lock.
 

--- a/assets/in
+++ b/assets/in
@@ -39,6 +39,7 @@ uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)
 pool_name=$(jq -r '.source.pool // ""' < $payload)
 ref=$(jq -r '.version.ref // "HEAD"' < $payload)
+depth=$(jq -r '(.params.depth // 0)' < $payload)
 
 if [ -z "$uri" ]; then
   config_errors="${config_errors}invalid payload (missing uri)\n"
@@ -62,7 +63,14 @@ if [ -n "$branch" ]; then
   branchflag="--branch $branch"
 fi
 
-git clone $uri $branchflag $destination
+
+depthflag=""
+if test "$depth" -gt 0 2> /dev/null; then
+  depthflag="--depth $depth"
+fi
+
+git clone $depthflag $uri $branchflag $destination
+
 
 cd $destination
 


### PR DESCRIPTION
"Some of the lock repos can get super big really fast, especially if multiple teams/pipelines are using the same repo. An idea is to use shallow clones, since we don't necessarily need the full history of the repo, we just need the latest state."

We wanted to implement the behavior that was requested in issue: https://github.com/concourse/pool-resource/issues/40 

This behaves the same exact way as the git-resource, as we wanted to maintain consistency. This is a parameter on the `get` step, the same way as described here: https://github.com/concourse/git-resource#in-clone-the-repository-at-the-given-ref

Authored-by: Maryam Labib <mlabib@pivotal.io>
co-authored by: Soumya GB <gowdabas@usc.edu>

Signed off by: Maryam Labib <mlabib@pivotal.io>
Signed off by: Soumya GB <gowdabas@usc.edu>