### PR TITLE
Revert "Make depth of 1 to be the default"

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -39,7 +39,7 @@ uri=$(jq -r '.source.uri // ""' < $payload)
 branch=$(jq -r '.source.branch // ""' < $payload)
 pool_name=$(jq -r '.source.pool // ""' < $payload)
 ref=$(jq -r '.version.ref // "HEAD"' < $payload)
-depth=$(jq -r '(.params.depth // 1)' < $payload)
+depth=$(jq -r '(.params.depth // 0)' < $payload)
 
 if [ -z "$uri" ]; then
   config_errors="${config_errors}invalid payload (missing uri)\n"
@@ -63,7 +63,10 @@ if [ -n "$branch" ]; then
   branchflag="--branch $branch"
 fi
 
-depthflag="--depth $depth"
+depthflag=""
+if test "$depth" -gt 0 2> /dev/null; then
+  depthflag="--depth $depth"
+fi
 
 git clone --single-branch $depthflag $uri $branchflag $destination
 


### PR DESCRIPTION
Reverts concourse/pool-resource#52

fixes #54 
fixes #55 

Making the clone too shallow breaks the `HEAD~1` comparison and also likely breaks the `git checkout` of the specified ref.

I'm not sure there's a sane default for the depth parameter, really. We faced this same problem with the `git` resource and ended up implementing a pretty complicated "deepening" loop.