### PR TITLE
use alpine:latest and ubuntu:latest as base

### DIFF
--- a/dockerfiles/alpine/Dockerfile
+++ b/dockerfiles/alpine/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:alpine as builder
+ARG base_image=alpine:latest
+ARG builder_image=concourse/golang-builder
+
+FROM ${builder_image} as builder
 COPY . /go/src/github.com/concourse/pool-resource
 ENV CGO_ENABLED 0
 ENV GOPATH /go/src/github.com/concourse/pool-resource/Godeps/_workspace:${GOPATH}
@@ -8,20 +11,20 @@ RUN set -e; for pkg in $(go list ./...); do \
 		go test -o "/tests/$(basename $pkg).test" -c $pkg; \
 	done
 
-FROM concourse/git-resource:alpine AS resource
-
+FROM ${base_image} AS resource
+RUN apk add --no-cache bash jq git git-daemon
+RUN git config --global user.email "git@localhost"
+RUN git config --global user.name "git"
 ADD assets/ /opt/resource/
 RUN chmod +x /opt/resource/*
-
 COPY --from=builder /assets /opt/go
 RUN chmod +x /opt/go/out
 
 FROM resource AS tests
 COPY --from=builder /tests /go/resource-tests/
 RUN set -e; for test in /go/resource-tests/*.test; do \
-		$test; \
+		$test -ginkgo.v; \
 	done
-
 ADD test/ /opt/resource-tests
 RUN /opt/resource-tests/all.sh
 

--- a/dockerfiles/ubuntu/Dockerfile
+++ b/dockerfiles/ubuntu/Dockerfile
@@ -1,4 +1,7 @@
-FROM concourse/golang-builder as builder
+ARG base_image
+ARG builder_image=concourse/golang-builder
+
+FROM ${builder_image} as builder
 COPY . /go/src/github.com/concourse/pool-resource
 ENV CGO_ENABLED 0
 ENV GOPATH /go/src/github.com/concourse/pool-resource/Godeps/_workspace:${GOPATH}
@@ -8,11 +11,13 @@ RUN set -e; for pkg in $(go list ./...); do \
 		go test -o "/tests/$(basename $pkg).test" -c $pkg; \
 	done
 
-FROM concourse/git-resource:ubuntu AS resource
+FROM ${base_image} AS resource
+RUN apt-get update && apt-get install -y jq git
+RUN git config --global user.email "git@localhost"
+RUN git config --global user.name "git"
 
 ADD assets/ /opt/resource/
 RUN chmod +x /opt/resource/*
-
 COPY --from=builder /assets /opt/go
 RUN chmod +x /opt/go/out
 
@@ -21,7 +26,6 @@ COPY --from=builder /tests /go/resource-tests/
 RUN set -e; for test in /go/resource-tests/*.test; do \
 		$test; \
 	done
-
 ADD test/ /opt/resource-tests
 RUN /opt/resource-tests/all.sh
 


### PR DESCRIPTION
rather than piggybacking on the git resource just to pull in 'git', just
get our own 'git' - it's pretty hard to reason about
inter-resource-image dependencies.

also:

* allow overriding FROM with build args
* use concourse/golang-builder (concourse/concourse#3826)

concourse/concourse#6425

Signed-off-by: Alex Suraci <suraci.alex@gmail.com>
