### PR TITLE
fix `private_key` usage on alpine image

### DIFF
--- a/dockerfiles/alpine/Dockerfile
+++ b/dockerfiles/alpine/Dockerfile
@@ -12,7 +12,7 @@ RUN set -e; for pkg in $(go list ./...); do \
 	done
 
 FROM ${base_image} AS resource
-RUN apk add --no-cache bash jq git git-daemon
+RUN apk add --no-cache bash jq git git-daemon openssh
 RUN git config --global user.email "git@localhost"
 RUN git config --global user.name "git"
 ADD assets/ /opt/resource/

--- a/test/check.sh
+++ b/test/check.sh
@@ -121,6 +121,15 @@ it_can_check_with_credentials() {
   [ ! -f "$HOME/.netrc" ]
 }
 
+it_supports_private_key_without_user() {
+  local repo=$(init_repo)
+  local key=$TMPDIR/key-no-passphrase
+
+  ssh-keygen -f $key
+  check_uri_with_key $repo $key
+
+  ! grep "^User " $HOME/.ssh/config
+}
 
 it_clears_netrc_even_after_errors() {
   local repo=$(init_repo)
@@ -146,4 +155,5 @@ run it_can_check_from_a_bogus_sha
 run it_checks_given_pool
 run it_can_check_when_not_ff
 run it_can_check_with_credentials
+run it_supports_private_key_without_user
 run it_clears_netrc_even_after_errors

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -174,3 +174,17 @@ check_uri_with_credentials() {
     }
   }" | ${resource_dir}/check | tee /dev/stderr
 }
+
+check_uri_with_key() {
+  local uri=$1
+  local key=$2
+
+  jq -n "{
+    source: {
+      uri: $(echo $uri | jq -R .),
+      branch: \"master\",
+      pool: \"my_pool\",
+      private_key: $(cat $key | jq -s -R .),
+    }
+  }" | ${resource_dir}/check | tee /dev/stderr
+}


### PR DESCRIPTION
Fixes #59 

and add minimal test coverage for using a private key

Signed-off-by: Aidan Oldershaw <aoldershaw@pivotal.io>