### PR TITLE
Avoid hard code git user name/email is already set

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Run the tests with the following commands for both `alpine` and `ubuntu` images:
 
 ```sh
 docker build -t pool-resource --target tests -f dockerfiles/alpine/Dockerfile .
-docker build -t pool-resource --target tests -f dockerfiles/ubuntu/Dockerfile .
+docker build -t pool-resource --target tests -f dockerfiles/ubuntu/Dockerfile --build-arg base_image=ubuntu:latest .
 ```
 
 #### Note about the integration tests

--- a/out/git_lock_handler.go
+++ b/out/git_lock_handler.go
@@ -205,14 +205,22 @@ func (glh *GitLockHandler) Setup() error {
 		return err
 	}
 
-	_, err = glh.git("config", "user.name", "CI Pool Resource")
+	_, err = glh.git("config", "user.name")
 	if err != nil {
-		return err
+		// hardcode git user.name if not already set in git_config
+		_, err = glh.git("config", "user.name", "CI Pool Resource")
+		if err != nil {
+			return err
+		}
 	}
 
-	_, err = glh.git("config", "user.email", "ci-pool@localhost")
+	_, err = glh.git("config", "user.email")
 	if err != nil {
-		return err
+		// hardcode git user.email if not already set in git_config
+		_, err = glh.git("config", "user.email", "ci-pool@localhost")
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The hard-coded git user name/email causes failures when the git server does pre-hook to verifying the push user and commit user must match.