### PR TITLE
Add check operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,21 @@ One of the following is required.
   `metadata` which should contain the name of your new lock and the contents you
   would like in the lock, respectively.
 
+* `check`: If set, we will check for an existing claimed lock in the pool and
+  wait until it becomes unclaimed.
+
+  * If there is an existing lock in claimed state: wait until lock is unclaimed
+  * If there is an existing lock in unclaimed state: no-op
+  * If no lock exists: fail
+
+  The purpose is to simply block until a given lock in a pool is moved from a
+  claimed state to an unclaimed state. This functionality allows us to build
+  dependencies between disparate pipelines without the need to `acquire` locks.
+
+  Note: the lock must be present to perform a check. In other words, a `get`
+  step to fetch metadata about the lock is necessary before a `put` step can
+  check the existence of the lock.
+
 ## Example Concourse Configuration
 
 The following example pipeline models acquiring, passing through, and releasing

--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -102,6 +102,14 @@ func main() {
 		}
 	}
 
+	if request.Params.Check != "" {
+		lockPath := filepath.Join(sourceDir, request.Params.Check)
+		lock, version, err = lockPool.CheckLock(lockPath)
+		if err != nil {
+			fatal("checking lock", err)
+		}
+	}
+
 	err = json.NewEncoder(os.Stdout).Encode(out.OutResponse{
 		Version: version,
 		Metadata: []out.MetadataPair{

--- a/out/fakes/fake_lock_handler.go
+++ b/out/fakes/fake_lock_handler.go
@@ -89,6 +89,19 @@ type FakeLockHandler struct {
 		result1 string
 		result2 error
 	}
+        CheckLockStub        func(lock string) (version string, err error)
+        checkLockMutex       sync.RWMutex
+        checkLockArgsForCall []struct {
+                lock string
+        }
+        checkLockReturns struct {
+                result1 string
+                result2 error
+        }
+        checkLockReturnsOnCall map[int]struct {
+                result1 string
+                result2 error
+        }
 	SetupStub        func() error
 	setupMutex       sync.RWMutex
 	setupArgsForCall []struct{}
@@ -434,6 +447,23 @@ func (fake *FakeLockHandler) UpdateLockReturnsOnCall(i int, result1 string, resu
 		result1 string
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeLockHandler) CheckLock(lock string) (version string, err error) {
+        fake.checkLockMutex.Lock()
+        ret, specificReturn := fake.checkLockReturnsOnCall[len(fake.checkLockArgsForCall)]
+        fake.checkLockArgsForCall = append(fake.checkLockArgsForCall, struct {
+                lock string
+        }{lock})
+        fake.recordInvocation("CheckLock", []interface{}{lock})
+        fake.checkLockMutex.Unlock()
+        if fake.CheckLockStub != nil {
+                return fake.CheckLockStub(lock)
+        }
+        if specificReturn {
+                return ret.result1, ret.result2
+        }
+	return fake.checkLockReturns.result1, fake.checkLockReturns.result2
 }
 
 func (fake *FakeLockHandler) Setup() error {

--- a/out/fakes/fake_lock_handler.go
+++ b/out/fakes/fake_lock_handler.go
@@ -8,38 +8,12 @@ import (
 )
 
 type FakeLockHandler struct {
-	GrabAvailableLockStub        func() (lock string, version string, err error)
-	grabAvailableLockMutex       sync.RWMutex
-	grabAvailableLockArgsForCall []struct{}
-	grabAvailableLockReturns     struct {
-		result1 string
-		result2 string
-		result3 error
-	}
-	grabAvailableLockReturnsOnCall map[int]struct {
-		result1 string
-		result2 string
-		result3 error
-	}
-	UnclaimLockStub        func(lock string) (version string, err error)
-	unclaimLockMutex       sync.RWMutex
-	unclaimLockArgsForCall []struct {
-		lock string
-	}
-	unclaimLockReturns struct {
-		result1 string
-		result2 error
-	}
-	unclaimLockReturnsOnCall map[int]struct {
-		result1 string
-		result2 error
-	}
-	AddLockStub        func(lock string, contents []byte, initiallyClaimed bool) (version string, err error)
+	AddLockStub        func(string, []byte, bool) (string, error)
 	addLockMutex       sync.RWMutex
 	addLockArgsForCall []struct {
-		lock             string
-		contents         []byte
-		initiallyClaimed bool
+		arg1 string
+		arg2 []byte
+		arg3 bool
 	}
 	addLockReturns struct {
 		result1 string
@@ -49,23 +23,35 @@ type FakeLockHandler struct {
 		result1 string
 		result2 error
 	}
-	RemoveLockStub        func(lock string) (version string, err error)
-	removeLockMutex       sync.RWMutex
-	removeLockArgsForCall []struct {
-		lock string
+	BroadcastLockPoolStub        func() ([]byte, error)
+	broadcastLockPoolMutex       sync.RWMutex
+	broadcastLockPoolArgsForCall []struct {
 	}
-	removeLockReturns struct {
+	broadcastLockPoolReturns struct {
+		result1 []byte
+		result2 error
+	}
+	broadcastLockPoolReturnsOnCall map[int]struct {
+		result1 []byte
+		result2 error
+	}
+	CheckLockStub        func(string) (string, error)
+	checkLockMutex       sync.RWMutex
+	checkLockArgsForCall []struct {
+		arg1 string
+	}
+	checkLockReturns struct {
 		result1 string
 		result2 error
 	}
-	removeLockReturnsOnCall map[int]struct {
+	checkLockReturnsOnCall map[int]struct {
 		result1 string
 		result2 error
 	}
-	ClaimLockStub        func(lock string) (version string, err error)
+	ClaimLockStub        func(string) (string, error)
 	claimLockMutex       sync.RWMutex
 	claimLockArgsForCall []struct {
-		lock string
+		arg1 string
 	}
 	claimLockReturns struct {
 		result1 string
@@ -75,11 +61,71 @@ type FakeLockHandler struct {
 		result1 string
 		result2 error
 	}
-	UpdateLockStub        func(lock string, contents []byte) (version string, err error)
+	GrabAvailableLockStub        func() (string, string, error)
+	grabAvailableLockMutex       sync.RWMutex
+	grabAvailableLockArgsForCall []struct {
+	}
+	grabAvailableLockReturns struct {
+		result1 string
+		result2 string
+		result3 error
+	}
+	grabAvailableLockReturnsOnCall map[int]struct {
+		result1 string
+		result2 string
+		result3 error
+	}
+	RemoveLockStub        func(string) (string, error)
+	removeLockMutex       sync.RWMutex
+	removeLockArgsForCall []struct {
+		arg1 string
+	}
+	removeLockReturns struct {
+		result1 string
+		result2 error
+	}
+	removeLockReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
+	ResetLockStub        func() error
+	resetLockMutex       sync.RWMutex
+	resetLockArgsForCall []struct {
+	}
+	resetLockReturns struct {
+		result1 error
+	}
+	resetLockReturnsOnCall map[int]struct {
+		result1 error
+	}
+	SetupStub        func() error
+	setupMutex       sync.RWMutex
+	setupArgsForCall []struct {
+	}
+	setupReturns struct {
+		result1 error
+	}
+	setupReturnsOnCall map[int]struct {
+		result1 error
+	}
+	UnclaimLockStub        func(string) (string, error)
+	unclaimLockMutex       sync.RWMutex
+	unclaimLockArgsForCall []struct {
+		arg1 string
+	}
+	unclaimLockReturns struct {
+		result1 string
+		result2 error
+	}
+	unclaimLockReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
+	UpdateLockStub        func(string, []byte) (string, error)
 	updateLockMutex       sync.RWMutex
 	updateLockArgsForCall []struct {
-		lock     string
-		contents []byte
+		arg1 string
+		arg2 []byte
 	}
 	updateLockReturns struct {
 		result1 string
@@ -89,65 +135,281 @@ type FakeLockHandler struct {
 		result1 string
 		result2 error
 	}
-        CheckLockStub        func(lock string) (version string, err error)
-        checkLockMutex       sync.RWMutex
-        checkLockArgsForCall []struct {
-                lock string
-        }
-        checkLockReturns struct {
-                result1 string
-                result2 error
-        }
-        checkLockReturnsOnCall map[int]struct {
-                result1 string
-                result2 error
-        }
-	SetupStub        func() error
-	setupMutex       sync.RWMutex
-	setupArgsForCall []struct{}
-	setupReturns     struct {
-		result1 error
-	}
-	setupReturnsOnCall map[int]struct {
-		result1 error
-	}
-	BroadcastLockPoolStub        func() ([]byte, error)
-	broadcastLockPoolMutex       sync.RWMutex
-	broadcastLockPoolArgsForCall []struct{}
-	broadcastLockPoolReturns     struct {
-		result1 []byte
-		result2 error
-	}
-	broadcastLockPoolReturnsOnCall map[int]struct {
-		result1 []byte
-		result2 error
-	}
-	ResetLockStub        func() error
-	resetLockMutex       sync.RWMutex
-	resetLockArgsForCall []struct{}
-	resetLockReturns     struct {
-		result1 error
-	}
-	resetLockReturnsOnCall map[int]struct {
-		result1 error
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeLockHandler) GrabAvailableLock() (lock string, version string, err error) {
+func (fake *FakeLockHandler) AddLock(arg1 string, arg2 []byte, arg3 bool) (string, error) {
+	var arg2Copy []byte
+	if arg2 != nil {
+		arg2Copy = make([]byte, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.addLockMutex.Lock()
+	ret, specificReturn := fake.addLockReturnsOnCall[len(fake.addLockArgsForCall)]
+	fake.addLockArgsForCall = append(fake.addLockArgsForCall, struct {
+		arg1 string
+		arg2 []byte
+		arg3 bool
+	}{arg1, arg2Copy, arg3})
+	stub := fake.AddLockStub
+	fakeReturns := fake.addLockReturns
+	fake.recordInvocation("AddLock", []interface{}{arg1, arg2Copy, arg3})
+	fake.addLockMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeLockHandler) AddLockCallCount() int {
+	fake.addLockMutex.RLock()
+	defer fake.addLockMutex.RUnlock()
+	return len(fake.addLockArgsForCall)
+}
+
+func (fake *FakeLockHandler) AddLockCalls(stub func(string, []byte, bool) (string, error)) {
+	fake.addLockMutex.Lock()
+	defer fake.addLockMutex.Unlock()
+	fake.AddLockStub = stub
+}
+
+func (fake *FakeLockHandler) AddLockArgsForCall(i int) (string, []byte, bool) {
+	fake.addLockMutex.RLock()
+	defer fake.addLockMutex.RUnlock()
+	argsForCall := fake.addLockArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeLockHandler) AddLockReturns(result1 string, result2 error) {
+	fake.addLockMutex.Lock()
+	defer fake.addLockMutex.Unlock()
+	fake.AddLockStub = nil
+	fake.addLockReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeLockHandler) AddLockReturnsOnCall(i int, result1 string, result2 error) {
+	fake.addLockMutex.Lock()
+	defer fake.addLockMutex.Unlock()
+	fake.AddLockStub = nil
+	if fake.addLockReturnsOnCall == nil {
+		fake.addLockReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.addLockReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeLockHandler) BroadcastLockPool() ([]byte, error) {
+	fake.broadcastLockPoolMutex.Lock()
+	ret, specificReturn := fake.broadcastLockPoolReturnsOnCall[len(fake.broadcastLockPoolArgsForCall)]
+	fake.broadcastLockPoolArgsForCall = append(fake.broadcastLockPoolArgsForCall, struct {
+	}{})
+	stub := fake.BroadcastLockPoolStub
+	fakeReturns := fake.broadcastLockPoolReturns
+	fake.recordInvocation("BroadcastLockPool", []interface{}{})
+	fake.broadcastLockPoolMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeLockHandler) BroadcastLockPoolCallCount() int {
+	fake.broadcastLockPoolMutex.RLock()
+	defer fake.broadcastLockPoolMutex.RUnlock()
+	return len(fake.broadcastLockPoolArgsForCall)
+}
+
+func (fake *FakeLockHandler) BroadcastLockPoolCalls(stub func() ([]byte, error)) {
+	fake.broadcastLockPoolMutex.Lock()
+	defer fake.broadcastLockPoolMutex.Unlock()
+	fake.BroadcastLockPoolStub = stub
+}
+
+func (fake *FakeLockHandler) BroadcastLockPoolReturns(result1 []byte, result2 error) {
+	fake.broadcastLockPoolMutex.Lock()
+	defer fake.broadcastLockPoolMutex.Unlock()
+	fake.BroadcastLockPoolStub = nil
+	fake.broadcastLockPoolReturns = struct {
+		result1 []byte
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeLockHandler) BroadcastLockPoolReturnsOnCall(i int, result1 []byte, result2 error) {
+	fake.broadcastLockPoolMutex.Lock()
+	defer fake.broadcastLockPoolMutex.Unlock()
+	fake.BroadcastLockPoolStub = nil
+	if fake.broadcastLockPoolReturnsOnCall == nil {
+		fake.broadcastLockPoolReturnsOnCall = make(map[int]struct {
+			result1 []byte
+			result2 error
+		})
+	}
+	fake.broadcastLockPoolReturnsOnCall[i] = struct {
+		result1 []byte
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeLockHandler) CheckLock(arg1 string) (string, error) {
+	fake.checkLockMutex.Lock()
+	ret, specificReturn := fake.checkLockReturnsOnCall[len(fake.checkLockArgsForCall)]
+	fake.checkLockArgsForCall = append(fake.checkLockArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.CheckLockStub
+	fakeReturns := fake.checkLockReturns
+	fake.recordInvocation("CheckLock", []interface{}{arg1})
+	fake.checkLockMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeLockHandler) CheckLockCallCount() int {
+	fake.checkLockMutex.RLock()
+	defer fake.checkLockMutex.RUnlock()
+	return len(fake.checkLockArgsForCall)
+}
+
+func (fake *FakeLockHandler) CheckLockCalls(stub func(string) (string, error)) {
+	fake.checkLockMutex.Lock()
+	defer fake.checkLockMutex.Unlock()
+	fake.CheckLockStub = stub
+}
+
+func (fake *FakeLockHandler) CheckLockArgsForCall(i int) string {
+	fake.checkLockMutex.RLock()
+	defer fake.checkLockMutex.RUnlock()
+	argsForCall := fake.checkLockArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeLockHandler) CheckLockReturns(result1 string, result2 error) {
+	fake.checkLockMutex.Lock()
+	defer fake.checkLockMutex.Unlock()
+	fake.CheckLockStub = nil
+	fake.checkLockReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeLockHandler) CheckLockReturnsOnCall(i int, result1 string, result2 error) {
+	fake.checkLockMutex.Lock()
+	defer fake.checkLockMutex.Unlock()
+	fake.CheckLockStub = nil
+	if fake.checkLockReturnsOnCall == nil {
+		fake.checkLockReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.checkLockReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeLockHandler) ClaimLock(arg1 string) (string, error) {
+	fake.claimLockMutex.Lock()
+	ret, specificReturn := fake.claimLockReturnsOnCall[len(fake.claimLockArgsForCall)]
+	fake.claimLockArgsForCall = append(fake.claimLockArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.ClaimLockStub
+	fakeReturns := fake.claimLockReturns
+	fake.recordInvocation("ClaimLock", []interface{}{arg1})
+	fake.claimLockMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeLockHandler) ClaimLockCallCount() int {
+	fake.claimLockMutex.RLock()
+	defer fake.claimLockMutex.RUnlock()
+	return len(fake.claimLockArgsForCall)
+}
+
+func (fake *FakeLockHandler) ClaimLockCalls(stub func(string) (string, error)) {
+	fake.claimLockMutex.Lock()
+	defer fake.claimLockMutex.Unlock()
+	fake.ClaimLockStub = stub
+}
+
+func (fake *FakeLockHandler) ClaimLockArgsForCall(i int) string {
+	fake.claimLockMutex.RLock()
+	defer fake.claimLockMutex.RUnlock()
+	argsForCall := fake.claimLockArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeLockHandler) ClaimLockReturns(result1 string, result2 error) {
+	fake.claimLockMutex.Lock()
+	defer fake.claimLockMutex.Unlock()
+	fake.ClaimLockStub = nil
+	fake.claimLockReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeLockHandler) ClaimLockReturnsOnCall(i int, result1 string, result2 error) {
+	fake.claimLockMutex.Lock()
+	defer fake.claimLockMutex.Unlock()
+	fake.ClaimLockStub = nil
+	if fake.claimLockReturnsOnCall == nil {
+		fake.claimLockReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.claimLockReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeLockHandler) GrabAvailableLock() (string, string, error) {
 	fake.grabAvailableLockMutex.Lock()
 	ret, specificReturn := fake.grabAvailableLockReturnsOnCall[len(fake.grabAvailableLockArgsForCall)]
-	fake.grabAvailableLockArgsForCall = append(fake.grabAvailableLockArgsForCall, struct{}{})
+	fake.grabAvailableLockArgsForCall = append(fake.grabAvailableLockArgsForCall, struct {
+	}{})
+	stub := fake.GrabAvailableLockStub
+	fakeReturns := fake.grabAvailableLockReturns
 	fake.recordInvocation("GrabAvailableLock", []interface{}{})
 	fake.grabAvailableLockMutex.Unlock()
-	if fake.GrabAvailableLockStub != nil {
-		return fake.GrabAvailableLockStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	return fake.grabAvailableLockReturns.result1, fake.grabAvailableLockReturns.result2, fake.grabAvailableLockReturns.result3
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *FakeLockHandler) GrabAvailableLockCallCount() int {
@@ -156,7 +418,15 @@ func (fake *FakeLockHandler) GrabAvailableLockCallCount() int {
 	return len(fake.grabAvailableLockArgsForCall)
 }
 
+func (fake *FakeLockHandler) GrabAvailableLockCalls(stub func() (string, string, error)) {
+	fake.grabAvailableLockMutex.Lock()
+	defer fake.grabAvailableLockMutex.Unlock()
+	fake.GrabAvailableLockStub = stub
+}
+
 func (fake *FakeLockHandler) GrabAvailableLockReturns(result1 string, result2 string, result3 error) {
+	fake.grabAvailableLockMutex.Lock()
+	defer fake.grabAvailableLockMutex.Unlock()
 	fake.GrabAvailableLockStub = nil
 	fake.grabAvailableLockReturns = struct {
 		result1 string
@@ -166,6 +436,8 @@ func (fake *FakeLockHandler) GrabAvailableLockReturns(result1 string, result2 st
 }
 
 func (fake *FakeLockHandler) GrabAvailableLockReturnsOnCall(i int, result1 string, result2 string, result3 error) {
+	fake.grabAvailableLockMutex.Lock()
+	defer fake.grabAvailableLockMutex.Unlock()
 	fake.GrabAvailableLockStub = nil
 	if fake.grabAvailableLockReturnsOnCall == nil {
 		fake.grabAvailableLockReturnsOnCall = make(map[int]struct {
@@ -181,130 +453,23 @@ func (fake *FakeLockHandler) GrabAvailableLockReturnsOnCall(i int, result1 strin
 	}{result1, result2, result3}
 }
 
-func (fake *FakeLockHandler) UnclaimLock(lock string) (version string, err error) {
-	fake.unclaimLockMutex.Lock()
-	ret, specificReturn := fake.unclaimLockReturnsOnCall[len(fake.unclaimLockArgsForCall)]
-	fake.unclaimLockArgsForCall = append(fake.unclaimLockArgsForCall, struct {
-		lock string
-	}{lock})
-	fake.recordInvocation("UnclaimLock", []interface{}{lock})
-	fake.unclaimLockMutex.Unlock()
-	if fake.UnclaimLockStub != nil {
-		return fake.UnclaimLockStub(lock)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.unclaimLockReturns.result1, fake.unclaimLockReturns.result2
-}
-
-func (fake *FakeLockHandler) UnclaimLockCallCount() int {
-	fake.unclaimLockMutex.RLock()
-	defer fake.unclaimLockMutex.RUnlock()
-	return len(fake.unclaimLockArgsForCall)
-}
-
-func (fake *FakeLockHandler) UnclaimLockArgsForCall(i int) string {
-	fake.unclaimLockMutex.RLock()
-	defer fake.unclaimLockMutex.RUnlock()
-	return fake.unclaimLockArgsForCall[i].lock
-}
-
-func (fake *FakeLockHandler) UnclaimLockReturns(result1 string, result2 error) {
-	fake.UnclaimLockStub = nil
-	fake.unclaimLockReturns = struct {
-		result1 string
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeLockHandler) UnclaimLockReturnsOnCall(i int, result1 string, result2 error) {
-	fake.UnclaimLockStub = nil
-	if fake.unclaimLockReturnsOnCall == nil {
-		fake.unclaimLockReturnsOnCall = make(map[int]struct {
-			result1 string
-			result2 error
-		})
-	}
-	fake.unclaimLockReturnsOnCall[i] = struct {
-		result1 string
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeLockHandler) AddLock(lock string, contents []byte, initiallyClaimed bool) (version string, err error) {
-	var contentsCopy []byte
-	if contents != nil {
-		contentsCopy = make([]byte, len(contents))
-		copy(contentsCopy, contents)
-	}
-	fake.addLockMutex.Lock()
-	ret, specificReturn := fake.addLockReturnsOnCall[len(fake.addLockArgsForCall)]
-	fake.addLockArgsForCall = append(fake.addLockArgsForCall, struct {
-		lock             string
-		contents         []byte
-		initiallyClaimed bool
-	}{lock, contentsCopy, initiallyClaimed})
-	fake.recordInvocation("AddLock", []interface{}{lock, contentsCopy, initiallyClaimed})
-	fake.addLockMutex.Unlock()
-	if fake.AddLockStub != nil {
-		return fake.AddLockStub(lock, contents, initiallyClaimed)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.addLockReturns.result1, fake.addLockReturns.result2
-}
-
-func (fake *FakeLockHandler) AddLockCallCount() int {
-	fake.addLockMutex.RLock()
-	defer fake.addLockMutex.RUnlock()
-	return len(fake.addLockArgsForCall)
-}
-
-func (fake *FakeLockHandler) AddLockArgsForCall(i int) (string, []byte, bool) {
-	fake.addLockMutex.RLock()
-	defer fake.addLockMutex.RUnlock()
-	return fake.addLockArgsForCall[i].lock, fake.addLockArgsForCall[i].contents, fake.addLockArgsForCall[i].initiallyClaimed
-}
-
-func (fake *FakeLockHandler) AddLockReturns(result1 string, result2 error) {
-	fake.AddLockStub = nil
-	fake.addLockReturns = struct {
-		result1 string
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeLockHandler) AddLockReturnsOnCall(i int, result1 string, result2 error) {
-	fake.AddLockStub = nil
-	if fake.addLockReturnsOnCall == nil {
-		fake.addLockReturnsOnCall = make(map[int]struct {
-			result1 string
-			result2 error
-		})
-	}
-	fake.addLockReturnsOnCall[i] = struct {
-		result1 string
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeLockHandler) RemoveLock(lock string) (version string, err error) {
+func (fake *FakeLockHandler) RemoveLock(arg1 string) (string, error) {
 	fake.removeLockMutex.Lock()
 	ret, specificReturn := fake.removeLockReturnsOnCall[len(fake.removeLockArgsForCall)]
 	fake.removeLockArgsForCall = append(fake.removeLockArgsForCall, struct {
-		lock string
-	}{lock})
-	fake.recordInvocation("RemoveLock", []interface{}{lock})
+		arg1 string
+	}{arg1})
+	stub := fake.RemoveLockStub
+	fakeReturns := fake.removeLockReturns
+	fake.recordInvocation("RemoveLock", []interface{}{arg1})
 	fake.removeLockMutex.Unlock()
-	if fake.RemoveLockStub != nil {
-		return fake.RemoveLockStub(lock)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.removeLockReturns.result1, fake.removeLockReturns.result2
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeLockHandler) RemoveLockCallCount() int {
@@ -313,13 +478,22 @@ func (fake *FakeLockHandler) RemoveLockCallCount() int {
 	return len(fake.removeLockArgsForCall)
 }
 
+func (fake *FakeLockHandler) RemoveLockCalls(stub func(string) (string, error)) {
+	fake.removeLockMutex.Lock()
+	defer fake.removeLockMutex.Unlock()
+	fake.RemoveLockStub = stub
+}
+
 func (fake *FakeLockHandler) RemoveLockArgsForCall(i int) string {
 	fake.removeLockMutex.RLock()
 	defer fake.removeLockMutex.RUnlock()
-	return fake.removeLockArgsForCall[i].lock
+	argsForCall := fake.removeLockArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeLockHandler) RemoveLockReturns(result1 string, result2 error) {
+	fake.removeLockMutex.Lock()
+	defer fake.removeLockMutex.Unlock()
 	fake.RemoveLockStub = nil
 	fake.removeLockReturns = struct {
 		result1 string
@@ -328,6 +502,8 @@ func (fake *FakeLockHandler) RemoveLockReturns(result1 string, result2 error) {
 }
 
 func (fake *FakeLockHandler) RemoveLockReturnsOnCall(i int, result1 string, result2 error) {
+	fake.removeLockMutex.Lock()
+	defer fake.removeLockMutex.Unlock()
 	fake.RemoveLockStub = nil
 	if fake.removeLockReturnsOnCall == nil {
 		fake.removeLockReturnsOnCall = make(map[int]struct {
@@ -341,78 +517,199 @@ func (fake *FakeLockHandler) RemoveLockReturnsOnCall(i int, result1 string, resu
 	}{result1, result2}
 }
 
-func (fake *FakeLockHandler) ClaimLock(lock string) (version string, err error) {
-	fake.claimLockMutex.Lock()
-	ret, specificReturn := fake.claimLockReturnsOnCall[len(fake.claimLockArgsForCall)]
-	fake.claimLockArgsForCall = append(fake.claimLockArgsForCall, struct {
-		lock string
-	}{lock})
-	fake.recordInvocation("ClaimLock", []interface{}{lock})
-	fake.claimLockMutex.Unlock()
-	if fake.ClaimLockStub != nil {
-		return fake.ClaimLockStub(lock)
+func (fake *FakeLockHandler) ResetLock() error {
+	fake.resetLockMutex.Lock()
+	ret, specificReturn := fake.resetLockReturnsOnCall[len(fake.resetLockArgsForCall)]
+	fake.resetLockArgsForCall = append(fake.resetLockArgsForCall, struct {
+	}{})
+	stub := fake.ResetLockStub
+	fakeReturns := fake.resetLockReturns
+	fake.recordInvocation("ResetLock", []interface{}{})
+	fake.resetLockMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLockHandler) ResetLockCallCount() int {
+	fake.resetLockMutex.RLock()
+	defer fake.resetLockMutex.RUnlock()
+	return len(fake.resetLockArgsForCall)
+}
+
+func (fake *FakeLockHandler) ResetLockCalls(stub func() error) {
+	fake.resetLockMutex.Lock()
+	defer fake.resetLockMutex.Unlock()
+	fake.ResetLockStub = stub
+}
+
+func (fake *FakeLockHandler) ResetLockReturns(result1 error) {
+	fake.resetLockMutex.Lock()
+	defer fake.resetLockMutex.Unlock()
+	fake.ResetLockStub = nil
+	fake.resetLockReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeLockHandler) ResetLockReturnsOnCall(i int, result1 error) {
+	fake.resetLockMutex.Lock()
+	defer fake.resetLockMutex.Unlock()
+	fake.ResetLockStub = nil
+	if fake.resetLockReturnsOnCall == nil {
+		fake.resetLockReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.resetLockReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeLockHandler) Setup() error {
+	fake.setupMutex.Lock()
+	ret, specificReturn := fake.setupReturnsOnCall[len(fake.setupArgsForCall)]
+	fake.setupArgsForCall = append(fake.setupArgsForCall, struct {
+	}{})
+	stub := fake.SetupStub
+	fakeReturns := fake.setupReturns
+	fake.recordInvocation("Setup", []interface{}{})
+	fake.setupMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeLockHandler) SetupCallCount() int {
+	fake.setupMutex.RLock()
+	defer fake.setupMutex.RUnlock()
+	return len(fake.setupArgsForCall)
+}
+
+func (fake *FakeLockHandler) SetupCalls(stub func() error) {
+	fake.setupMutex.Lock()
+	defer fake.setupMutex.Unlock()
+	fake.SetupStub = stub
+}
+
+func (fake *FakeLockHandler) SetupReturns(result1 error) {
+	fake.setupMutex.Lock()
+	defer fake.setupMutex.Unlock()
+	fake.SetupStub = nil
+	fake.setupReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeLockHandler) SetupReturnsOnCall(i int, result1 error) {
+	fake.setupMutex.Lock()
+	defer fake.setupMutex.Unlock()
+	fake.SetupStub = nil
+	if fake.setupReturnsOnCall == nil {
+		fake.setupReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.setupReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeLockHandler) UnclaimLock(arg1 string) (string, error) {
+	fake.unclaimLockMutex.Lock()
+	ret, specificReturn := fake.unclaimLockReturnsOnCall[len(fake.unclaimLockArgsForCall)]
+	fake.unclaimLockArgsForCall = append(fake.unclaimLockArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.UnclaimLockStub
+	fakeReturns := fake.unclaimLockReturns
+	fake.recordInvocation("UnclaimLock", []interface{}{arg1})
+	fake.unclaimLockMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.claimLockReturns.result1, fake.claimLockReturns.result2
+	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeLockHandler) ClaimLockCallCount() int {
-	fake.claimLockMutex.RLock()
-	defer fake.claimLockMutex.RUnlock()
-	return len(fake.claimLockArgsForCall)
+func (fake *FakeLockHandler) UnclaimLockCallCount() int {
+	fake.unclaimLockMutex.RLock()
+	defer fake.unclaimLockMutex.RUnlock()
+	return len(fake.unclaimLockArgsForCall)
 }
 
-func (fake *FakeLockHandler) ClaimLockArgsForCall(i int) string {
-	fake.claimLockMutex.RLock()
-	defer fake.claimLockMutex.RUnlock()
-	return fake.claimLockArgsForCall[i].lock
+func (fake *FakeLockHandler) UnclaimLockCalls(stub func(string) (string, error)) {
+	fake.unclaimLockMutex.Lock()
+	defer fake.unclaimLockMutex.Unlock()
+	fake.UnclaimLockStub = stub
 }
 
-func (fake *FakeLockHandler) ClaimLockReturns(result1 string, result2 error) {
-	fake.ClaimLockStub = nil
-	fake.claimLockReturns = struct {
+func (fake *FakeLockHandler) UnclaimLockArgsForCall(i int) string {
+	fake.unclaimLockMutex.RLock()
+	defer fake.unclaimLockMutex.RUnlock()
+	argsForCall := fake.unclaimLockArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeLockHandler) UnclaimLockReturns(result1 string, result2 error) {
+	fake.unclaimLockMutex.Lock()
+	defer fake.unclaimLockMutex.Unlock()
+	fake.UnclaimLockStub = nil
+	fake.unclaimLockReturns = struct {
 		result1 string
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeLockHandler) ClaimLockReturnsOnCall(i int, result1 string, result2 error) {
-	fake.ClaimLockStub = nil
-	if fake.claimLockReturnsOnCall == nil {
-		fake.claimLockReturnsOnCall = make(map[int]struct {
+func (fake *FakeLockHandler) UnclaimLockReturnsOnCall(i int, result1 string, result2 error) {
+	fake.unclaimLockMutex.Lock()
+	defer fake.unclaimLockMutex.Unlock()
+	fake.UnclaimLockStub = nil
+	if fake.unclaimLockReturnsOnCall == nil {
+		fake.unclaimLockReturnsOnCall = make(map[int]struct {
 			result1 string
 			result2 error
 		})
 	}
-	fake.claimLockReturnsOnCall[i] = struct {
+	fake.unclaimLockReturnsOnCall[i] = struct {
 		result1 string
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeLockHandler) UpdateLock(lock string, contents []byte) (version string, err error) {
-	var contentsCopy []byte
-	if contents != nil {
-		contentsCopy = make([]byte, len(contents))
-		copy(contentsCopy, contents)
+func (fake *FakeLockHandler) UpdateLock(arg1 string, arg2 []byte) (string, error) {
+	var arg2Copy []byte
+	if arg2 != nil {
+		arg2Copy = make([]byte, len(arg2))
+		copy(arg2Copy, arg2)
 	}
 	fake.updateLockMutex.Lock()
 	ret, specificReturn := fake.updateLockReturnsOnCall[len(fake.updateLockArgsForCall)]
 	fake.updateLockArgsForCall = append(fake.updateLockArgsForCall, struct {
-		lock     string
-		contents []byte
-	}{lock, contentsCopy})
-	fake.recordInvocation("UpdateLock", []interface{}{lock, contentsCopy})
+		arg1 string
+		arg2 []byte
+	}{arg1, arg2Copy})
+	stub := fake.UpdateLockStub
+	fakeReturns := fake.updateLockReturns
+	fake.recordInvocation("UpdateLock", []interface{}{arg1, arg2Copy})
 	fake.updateLockMutex.Unlock()
-	if fake.UpdateLockStub != nil {
-		return fake.UpdateLockStub(lock, contents)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.updateLockReturns.result1, fake.updateLockReturns.result2
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeLockHandler) UpdateLockCallCount() int {
@@ -421,13 +718,22 @@ func (fake *FakeLockHandler) UpdateLockCallCount() int {
 	return len(fake.updateLockArgsForCall)
 }
 
+func (fake *FakeLockHandler) UpdateLockCalls(stub func(string, []byte) (string, error)) {
+	fake.updateLockMutex.Lock()
+	defer fake.updateLockMutex.Unlock()
+	fake.UpdateLockStub = stub
+}
+
 func (fake *FakeLockHandler) UpdateLockArgsForCall(i int) (string, []byte) {
 	fake.updateLockMutex.RLock()
 	defer fake.updateLockMutex.RUnlock()
-	return fake.updateLockArgsForCall[i].lock, fake.updateLockArgsForCall[i].contents
+	argsForCall := fake.updateLockArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeLockHandler) UpdateLockReturns(result1 string, result2 error) {
+	fake.updateLockMutex.Lock()
+	defer fake.updateLockMutex.Unlock()
 	fake.UpdateLockStub = nil
 	fake.updateLockReturns = struct {
 		result1 string
@@ -436,6 +742,8 @@ func (fake *FakeLockHandler) UpdateLockReturns(result1 string, result2 error) {
 }
 
 func (fake *FakeLockHandler) UpdateLockReturnsOnCall(i int, result1 string, result2 error) {
+	fake.updateLockMutex.Lock()
+	defer fake.updateLockMutex.Unlock()
 	fake.UpdateLockStub = nil
 	if fake.updateLockReturnsOnCall == nil {
 		fake.updateLockReturnsOnCall = make(map[int]struct {
@@ -449,167 +757,29 @@ func (fake *FakeLockHandler) UpdateLockReturnsOnCall(i int, result1 string, resu
 	}{result1, result2}
 }
 
-func (fake *FakeLockHandler) CheckLock(lock string) (version string, err error) {
-        fake.checkLockMutex.Lock()
-        ret, specificReturn := fake.checkLockReturnsOnCall[len(fake.checkLockArgsForCall)]
-        fake.checkLockArgsForCall = append(fake.checkLockArgsForCall, struct {
-                lock string
-        }{lock})
-        fake.recordInvocation("CheckLock", []interface{}{lock})
-        fake.checkLockMutex.Unlock()
-        if fake.CheckLockStub != nil {
-                return fake.CheckLockStub(lock)
-        }
-        if specificReturn {
-                return ret.result1, ret.result2
-        }
-	return fake.checkLockReturns.result1, fake.checkLockReturns.result2
-}
-
-func (fake *FakeLockHandler) Setup() error {
-	fake.setupMutex.Lock()
-	ret, specificReturn := fake.setupReturnsOnCall[len(fake.setupArgsForCall)]
-	fake.setupArgsForCall = append(fake.setupArgsForCall, struct{}{})
-	fake.recordInvocation("Setup", []interface{}{})
-	fake.setupMutex.Unlock()
-	if fake.SetupStub != nil {
-		return fake.SetupStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.setupReturns.result1
-}
-
-func (fake *FakeLockHandler) SetupCallCount() int {
-	fake.setupMutex.RLock()
-	defer fake.setupMutex.RUnlock()
-	return len(fake.setupArgsForCall)
-}
-
-func (fake *FakeLockHandler) SetupReturns(result1 error) {
-	fake.SetupStub = nil
-	fake.setupReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeLockHandler) SetupReturnsOnCall(i int, result1 error) {
-	fake.SetupStub = nil
-	if fake.setupReturnsOnCall == nil {
-		fake.setupReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.setupReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeLockHandler) BroadcastLockPool() ([]byte, error) {
-	fake.broadcastLockPoolMutex.Lock()
-	ret, specificReturn := fake.broadcastLockPoolReturnsOnCall[len(fake.broadcastLockPoolArgsForCall)]
-	fake.broadcastLockPoolArgsForCall = append(fake.broadcastLockPoolArgsForCall, struct{}{})
-	fake.recordInvocation("BroadcastLockPool", []interface{}{})
-	fake.broadcastLockPoolMutex.Unlock()
-	if fake.BroadcastLockPoolStub != nil {
-		return fake.BroadcastLockPoolStub()
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.broadcastLockPoolReturns.result1, fake.broadcastLockPoolReturns.result2
-}
-
-func (fake *FakeLockHandler) BroadcastLockPoolCallCount() int {
-	fake.broadcastLockPoolMutex.RLock()
-	defer fake.broadcastLockPoolMutex.RUnlock()
-	return len(fake.broadcastLockPoolArgsForCall)
-}
-
-func (fake *FakeLockHandler) BroadcastLockPoolReturns(result1 []byte, result2 error) {
-	fake.BroadcastLockPoolStub = nil
-	fake.broadcastLockPoolReturns = struct {
-		result1 []byte
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeLockHandler) BroadcastLockPoolReturnsOnCall(i int, result1 []byte, result2 error) {
-	fake.BroadcastLockPoolStub = nil
-	if fake.broadcastLockPoolReturnsOnCall == nil {
-		fake.broadcastLockPoolReturnsOnCall = make(map[int]struct {
-			result1 []byte
-			result2 error
-		})
-	}
-	fake.broadcastLockPoolReturnsOnCall[i] = struct {
-		result1 []byte
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeLockHandler) ResetLock() error {
-	fake.resetLockMutex.Lock()
-	ret, specificReturn := fake.resetLockReturnsOnCall[len(fake.resetLockArgsForCall)]
-	fake.resetLockArgsForCall = append(fake.resetLockArgsForCall, struct{}{})
-	fake.recordInvocation("ResetLock", []interface{}{})
-	fake.resetLockMutex.Unlock()
-	if fake.ResetLockStub != nil {
-		return fake.ResetLockStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.resetLockReturns.result1
-}
-
-func (fake *FakeLockHandler) ResetLockCallCount() int {
-	fake.resetLockMutex.RLock()
-	defer fake.resetLockMutex.RUnlock()
-	return len(fake.resetLockArgsForCall)
-}
-
-func (fake *FakeLockHandler) ResetLockReturns(result1 error) {
-	fake.ResetLockStub = nil
-	fake.resetLockReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeLockHandler) ResetLockReturnsOnCall(i int, result1 error) {
-	fake.ResetLockStub = nil
-	if fake.resetLockReturnsOnCall == nil {
-		fake.resetLockReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.resetLockReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
 func (fake *FakeLockHandler) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.grabAvailableLockMutex.RLock()
-	defer fake.grabAvailableLockMutex.RUnlock()
-	fake.unclaimLockMutex.RLock()
-	defer fake.unclaimLockMutex.RUnlock()
 	fake.addLockMutex.RLock()
 	defer fake.addLockMutex.RUnlock()
-	fake.removeLockMutex.RLock()
-	defer fake.removeLockMutex.RUnlock()
-	fake.claimLockMutex.RLock()
-	defer fake.claimLockMutex.RUnlock()
-	fake.updateLockMutex.RLock()
-	defer fake.updateLockMutex.RUnlock()
-	fake.setupMutex.RLock()
-	defer fake.setupMutex.RUnlock()
 	fake.broadcastLockPoolMutex.RLock()
 	defer fake.broadcastLockPoolMutex.RUnlock()
+	fake.checkLockMutex.RLock()
+	defer fake.checkLockMutex.RUnlock()
+	fake.claimLockMutex.RLock()
+	defer fake.claimLockMutex.RUnlock()
+	fake.grabAvailableLockMutex.RLock()
+	defer fake.grabAvailableLockMutex.RUnlock()
+	fake.removeLockMutex.RLock()
+	defer fake.removeLockMutex.RUnlock()
 	fake.resetLockMutex.RLock()
 	defer fake.resetLockMutex.RUnlock()
+	fake.setupMutex.RLock()
+	defer fake.setupMutex.RUnlock()
+	fake.unclaimLockMutex.RLock()
+	defer fake.unclaimLockMutex.RUnlock()
+	fake.updateLockMutex.RLock()
+	defer fake.updateLockMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/out/git_lock_handler.go
+++ b/out/git_lock_handler.go
@@ -18,13 +18,13 @@ var ErrLockActive = errors.New("lock found")
 type GitLockHandler struct {
 	Source Source
 
-	dir string
+	dir       string
+	checkOnly bool
 }
 
 const falsePushString = "Everything up-to-date"
 const pushRejectedString = "[rejected]"
 const pushRemoteRejectedString = "[remote rejected]"
-const checkOnly = "check_only"
 
 func NewGitLockHandler(source Source) *GitLockHandler {
 	return &GitLockHandler{
@@ -194,15 +194,12 @@ func (glh *GitLockHandler) UpdateLock(lockName string, contents []byte) (string,
 }
 
 func (glh *GitLockHandler) CheckLock(lockName string) (string, error) {
+	glh.checkOnly = true
+
 	// Wait if claimed
 	_, err := ioutil.ReadFile(filepath.Join(glh.dir, glh.Source.Pool, "claimed", lockName))
 	if err == nil {
 		return "", ErrLockActive
-	}
-
-	err = ioutil.WriteFile(checkOnly, []byte{}, 0555)
-	if err != nil {
-		return "", err
 	}
 
 	_, err = glh.git("pull", "origin", glh.Source.Branch)
@@ -295,11 +292,8 @@ func (glh *GitLockHandler) GrabAvailableLock() (string, string, error) {
 }
 
 func (glh *GitLockHandler) BroadcastLockPool() ([]byte, error) {
-	_, err := os.Stat(checkOnly)
-
 	// validate if we're doing check only
-	if !os.IsNotExist(err) {
-		os.Remove(checkOnly)
+	if glh.checkOnly {
 		return []byte{}, nil
 	}
 

--- a/out/lock_pool.go
+++ b/out/lock_pool.go
@@ -37,6 +37,7 @@ type LockHandler interface {
 	RemoveLock(lock string) (version string, err error)
 	ClaimLock(lock string) (version string, err error)
 	UpdateLock(lock string, contents []byte) (version string, err error)
+	CheckLock(lock string) (version string, err error)
 
 	Setup() error
 	BroadcastLockPool() ([]byte, error)
@@ -260,6 +261,42 @@ func (lp *LockPool) UpdateLock(inDir string) (string, Version, error) {
 		return "", Version{}, err
 	}
 	fmt.Fprintf(lp.Output, "\nupdated!\n")
+
+	return lockName, Version{
+		Ref: strings.TrimSpace(ref),
+	}, nil
+}
+
+func (lp *LockPool) CheckLock(inDir string) (string, Version, error) {
+	nameFileContents, err := ioutil.ReadFile(filepath.Join(inDir, "name"))
+	if err != nil {
+		return "", Version{}, fmt.Errorf("could not read the name file of your lock: %s", err)
+	}
+	lockName := strings.TrimSpace(string(nameFileContents))
+
+	fmt.Fprintf(lp.Output, "checking lock: %s in pool: %s\n", lockName, lp.Source.Pool)
+
+	var ref string
+
+	err = lp.performRobustAction(func() (bool, error) {
+		var err error
+		ref, err = lp.LockHandler.CheckLock(lockName)
+
+		if err == ErrLockActive {
+			fmt.Fprint(lp.Output, ".")
+			return true, nil
+		}
+
+		if err != nil {
+			fmt.Fprintf(lp.Output, "failed to check the lock: %s! (err: %s) retrying...\n", lockName, err)
+			return true, nil
+		}
+		return false, nil
+	})
+
+	if err != nil {
+		return "", Version{}, err
+	}
 
 	return lockName, Version{
 		Ref: strings.TrimSpace(ref),

--- a/out/lock_pool.go
+++ b/out/lock_pool.go
@@ -275,6 +275,7 @@ func (lp *LockPool) CheckLock(inDir string) (string, Version, error) {
 	lockName := strings.TrimSpace(string(nameFileContents))
 
 	fmt.Fprintf(lp.Output, "checking lock: %s in pool: %s\n", lockName, lp.Source.Pool)
+	fmt.Fprintf(lp.Output, "waiting for lock to become unclaimed\n")
 
 	var ref string
 

--- a/out/lock_pool.go
+++ b/out/lock_pool.go
@@ -271,7 +271,7 @@ func (lp *LockPool) UpdateLock(inDir string) (string, Version, error) {
 func (lp *LockPool) CheckLock(inDir string) (string, Version, error) {
 	nameFileContents, err := ioutil.ReadFile(filepath.Join(inDir, "name"))
 	if err != nil {
-		return "", Version{}, fmt.Errorf("could not read the name file of your lock: %s", err)
+		return "", Version{}, fmt.Errorf("could not read the file name of your lock: %s", err)
 	}
 	lockName := strings.TrimSpace(string(nameFileContents))
 

--- a/out/lock_pool.go
+++ b/out/lock_pool.go
@@ -16,6 +16,7 @@ type LockPool struct {
 
 	LockHandler LockHandler
 	dir         string
+	checkOnly   bool
 }
 
 func NewLockPool(source Source, output io.Writer) LockPool {

--- a/out/lock_pool_test.go
+++ b/out/lock_pool_test.go
@@ -790,7 +790,7 @@ var _ = Describe("Lock Pool", func() {
 					})
 				})
 
-				Context( "when resetting the lock succeeds", func() {
+				Context("when resetting the lock succeeds", func() {
 					It("tries to update the lock it found in the name file", func() {
 						_, _, err := lockPool.UpdateLock(lockDir)
 						Ω(err).ShouldNot(HaveOccurred())

--- a/out/lock_pool_test.go
+++ b/out/lock_pool_test.go
@@ -861,71 +861,71 @@ var _ = Describe("Lock Pool", func() {
 		})
 	})
 
-        Context("Checking a lock", func() {
-                var lockDir string
+	Context("Checking a lock", func() {
+		var lockDir string
 
-                BeforeEach(func() {
-                        var err error
-                        lockDir, err = ioutil.TempDir("", "lock-dir")
-                        Ω(err).ShouldNot(HaveOccurred())
+		BeforeEach(func() {
+			var err error
+			lockDir, err = ioutil.TempDir("", "lock-dir")
+			Ω(err).ShouldNot(HaveOccurred())
 
-                })
+		})
 
-                AfterEach(func() {
-                        err := os.RemoveAll(lockDir)
-                        Ω(err).ShouldNot(HaveOccurred())
-                })
+		AfterEach(func() {
+			err := os.RemoveAll(lockDir)
+			Ω(err).ShouldNot(HaveOccurred())
+		})
 
-                Context("when a name file doesn't exist", func() {
-                        It("returns an error", func() {
-                                _, _, err := lockPool.CheckLock(lockDir)
-                                Ω(err).Should(HaveOccurred())
-                        })
-                })
+		Context("when a name file doesn't exist", func() {
+			It("returns an error", func() {
+				_, _, err := lockPool.CheckLock(lockDir)
+				Ω(err).Should(HaveOccurred())
+			})
+		})
 
-                Context("when a name file does exist", func() {
-                        BeforeEach(func() {
-                                err := ioutil.WriteFile(filepath.Join(lockDir, "name"), []byte("some-lock"), 0755)
-                                Ω(err).ShouldNot(HaveOccurred())
-                        })
+		Context("when a name file does exist", func() {
+			BeforeEach(func() {
+				err := ioutil.WriteFile(filepath.Join(lockDir, "name"), []byte("some-lock"), 0755)
+				Ω(err).ShouldNot(HaveOccurred())
+			})
 
-                        Context("when setup fails", func() {
-                                BeforeEach(func() {
-                                        fakeLockHandler.SetupReturns(errors.New("some-error"))
-                                })
+			Context("when setup fails", func() {
+				BeforeEach(func() {
+					fakeLockHandler.SetupReturns(errors.New("some-error"))
+				})
 
-                                It("returns an error", func() {
-                                        _, _, err := lockPool.CheckLock(lockDir)
-                                        Ω(err).Should(HaveOccurred())
-                                })
-                        })
+				It("returns an error", func() {
+					_, _, err := lockPool.CheckLock(lockDir)
+					Ω(err).Should(HaveOccurred())
+				})
+			})
 
-                        Context("when setup succeeds", func() {
-                                Context("when the lock is unclaimed", func() {
-                                        BeforeEach(func() {
-                                                fakeLockHandler.CheckLockReturns("some-ref", nil)
-                                        })
+			Context("when setup succeeds", func() {
+				Context("when the lock is unclaimed", func() {
+					BeforeEach(func() {
+						fakeLockHandler.CheckLockReturns("some-ref", nil)
+					})
 
-                                        It("bypasses broadcasting to the lock pool", func() {
-                                                _, _, err := lockPool.CheckLock(lockDir)
-                                                Ω(err).ShouldNot(HaveOccurred())
+					It("bypasses broadcasting to the lock pool", func() {
+						_, _, err := lockPool.CheckLock(lockDir)
+						Ω(err).ShouldNot(HaveOccurred())
 
-                                                Ω(fakeLockHandler.BroadcastLockPoolCallCount()).Should(Equal(1))
-                                        })
+						Ω(fakeLockHandler.BroadcastLockPoolCallCount()).Should(Equal(1))
+					})
 
-                                        Context("when broadcasting succeeds", func() {
-                                                It("returns the lockname, and a version", func() {
-                                                        lockName, version, err := lockPool.CheckLock(lockDir)
+					Context("when broadcasting succeeds", func() {
+						It("returns the lockname, and a version", func() {
+							lockName, version, err := lockPool.CheckLock(lockDir)
 
-                                                        Ω(err).ShouldNot(HaveOccurred())
-                                                        Ω(lockName).Should(Equal("some-lock"))
-                                                        Ω(version).Should(Equal(out.Version{
-                                                                Ref: "some-ref",
-                                                        }))
-                                                })
-                                        })
-                                })
-                        })
-                })
-        })
+							Ω(err).ShouldNot(HaveOccurred())
+							Ω(lockName).Should(Equal("some-lock"))
+							Ω(version).Should(Equal(out.Version{
+								Ref: "some-ref",
+							}))
+						})
+					})
+				})
+			})
+		})
+	})
 })

--- a/out/out_request.go
+++ b/out/out_request.go
@@ -80,7 +80,7 @@ func (request OutRequest) Validate() []string {
 		request.Params.Claim == "" &&
 		request.Params.Update == "" &&
 		request.Params.Check == "" {
-		errorMessages = append(errorMessages, "invalid payload (missing acquire, release, remove, claim, add, or add_claimed)")
+		errorMessages = append(errorMessages, "invalid payload (missing acquire, release, remove, claim, add, add_claimed, update, or check)")
 	}
 
 	return errorMessages

--- a/out/out_request.go
+++ b/out/out_request.go
@@ -54,6 +54,7 @@ type OutParams struct {
 	Remove     string `json:"remove"`
 	Claim      string `json:"claim"`
 	Update     string `json:"update"`
+	Check      string `json:"check"`
 }
 
 func (request OutRequest) Validate() []string {
@@ -77,7 +78,8 @@ func (request OutRequest) Validate() []string {
 		request.Params.AddClaimed == "" &&
 		request.Params.Remove == "" &&
 		request.Params.Claim == "" &&
-		request.Params.Update == "" {
+		request.Params.Update == "" &&
+		request.Params.Check == "" {
 		errorMessages = append(errorMessages, "invalid payload (missing acquire, release, remove, claim, add, or add_claimed)")
 	}
 


### PR DESCRIPTION
This PR adds the functionality to `check` a given lock in a pool and block/wait until that lock becomes unclaimed.
The rational behind it is as follows:

Given that we have multiple disparate pipelines that may trigger in any order:

- we would like a `build` pipeline to be able to claim the lock for the duration of a number of tasks (e.g Docker build/push) and release the lock afterwards
- the second (or multiple) `deploy` pipeline should wait until the `build` pipeline is completed before proceeding to pull in the updated output (ie. the Docker image built in `build` pipeline)

The intent is to have the `deploy` pipelines always use the latest available output (Docker image), and if there is an active build taking place to produce said output (Docker image), then we want to wait/block until that output is ready/published. 

Now we could simply use `acquire` across all the pipelines, but this feel clunky since we'd end up dealing with `deploy` pipelines acquiring the locks unnecessarily, when all we want to do is check for existence of a claimed lock by the `build` pipeline only. This is especially true in cases of many:1 dependency in pipelines - we want to avoid hundreds of pipelines trying to `acquire` a lock unnecessarily.

check details in docs:

* `check`: If set, we will check for an existing claimed lock in the pool and wait until it becomes unclaimed.

  * If there is an existing lock in claimed state: wait until lock is unclaimed
  * If there is an existing lock in unclaimed state: no-op
  * If no lock exists: fail
 
  The purpose is to simply block until a given lock in a pool is moved from a
  claimed state to an unclaimed state. This functionality allows us to build
  dependencies between disparate pipelines without the need to `acquire` locks.

  Note: the lock must be present to perform a check. In other words, a `get`
  step to fetch metadata about the lock is necessary before a `put` step can
  check the existence of the lock.

Thanks in advance for the review!

cc @xtremerui 