### PR TITLE
Use a trap to kill /opt/go/out when term is sent by concourse

### DIFF
--- a/assets/out
+++ b/assets/out
@@ -17,4 +17,13 @@ git_config_payload=$(jq -r '.source.git_config // []' < $payload)
 
 configure_git_global "${git_config_payload}"
 
-/opt/go/out $1 >&3 < $payload
+_terminate() {
+  kill -TERM "$child" 2>/dev/null
+}
+
+trap _terminate TERM
+
+/opt/go/out $1 >&3 < $payload &
+
+child=$!
+wait "$child"


### PR DESCRIPTION
Fixes https://github.com/concourse/pool-resource/issues/70

The TERM signal which is sent by concourse to abort the task (either from the UI, or via cli command) is not being forwarded onto the go process, the assets/out script is terminated, but there is still a running go process, this causes the task not to exit and hang until the lock can be claimed, once it is claimed the task exits with a failure and the lock is deadlocked until intervention.

This PR:
1. Spawns the go process in the background
2. Sets up a trap on TERM which will send a TERM to the go process
3. Waits for the go process

I have tested this and it works with both username/password auth, and with private key auth (the ssh-agents trap is also working and terminating the ssh-agent correctly).

Unlike the screenshots in the mentioned issue you can see this example which terminated correctly when clicking the abort button in concourse

![Screenshot 2024-05-15 at 17 01 14](https://github.com/concourse/pool-resource/assets/2170030/eedde355-1496-4ad2-9651-cef783f8ea3d)
