### PR TITLE
Include pipeline instance vars in the commit message prefix if set

### DIFF
--- a/out/git_lock_handler.go
+++ b/out/git_lock_handler.go
@@ -354,11 +354,10 @@ func (glh *GitLockHandler) messagePrefix() string {
 	instanceVars := os.Getenv("BUILD_PIPELINE_INSTANCE_VARS")
 
 	if buildName != "" && jobName != "" && pipelineName != "" && teamName != "" {
-		prefix := fmt.Sprintf("%s/%s/%s build %s", teamName, pipelineName, jobName, buildName)
 		if instanceVars != "" {
-			prefix += fmt.Sprintf(" %s", instanceVars)
+			return fmt.Sprintf("%s/%s/%s/%s build %s ", teamName, pipelineName, instanceVars, jobName, buildName)
 		}
-		return prefix + " "
+		return fmt.Sprintf("%s/%s/%s build %s ", teamName, pipelineName, jobName, buildName)
 	} else if buildID != "" {
 		return fmt.Sprintf("one-off build %s ", buildID)
 	}

--- a/out/git_lock_handler.go
+++ b/out/git_lock_handler.go
@@ -351,9 +351,14 @@ func (glh *GitLockHandler) messagePrefix() string {
 	jobName := os.Getenv("BUILD_JOB_NAME")
 	pipelineName := os.Getenv("BUILD_PIPELINE_NAME")
 	teamName := os.Getenv("BUILD_TEAM_NAME")
+	instanceVars := os.Getenv("BUILD_PIPELINE_INSTANCE_VARS")
 
 	if buildName != "" && jobName != "" && pipelineName != "" && teamName != "" {
-		return fmt.Sprintf("%s/%s/%s build %s ", teamName, pipelineName, jobName, buildName)
+		prefix := fmt.Sprintf("%s/%s/%s build %s", teamName, pipelineName, jobName, buildName)
+		if instanceVars != "" {
+			prefix += fmt.Sprintf(" %s", instanceVars)
+		}
+		return prefix + " "
 	} else if buildID != "" {
 		return fmt.Sprintf("one-off build %s ", buildID)
 	}


### PR DESCRIPTION
We use the same pool across a large number of instanced pipelines and sometimes when a lock is acquired it's difficult to determine which pipeline is responsible as we don't have the instance var information in the commit message.
