### PR TITLE
Include BUILD_URL in commit message

### DIFF
--- a/cmd/out/main.go
+++ b/cmd/out/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"time"
@@ -11,9 +10,6 @@ import (
 )
 
 func main() {
-
-	rand.Seed(time.Now().UnixNano())
-
 	if len(os.Args) < 2 {
 		println("usage: " + os.Args[0] + " <source>")
 		os.Exit(1)

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -79,11 +79,7 @@ func runOut(request out.OutRequest, sourceDir string) *gexec.Session {
 
 	outCmd.Env = append(
 		os.Environ(),
-		"BUILD_ID=1234",
-		"BUILD_NAME=42",
-		"BUILD_JOB_NAME=job-name",
-		"BUILD_PIPELINE_NAME=pipeline-name",
-		"BUILD_TEAM_NAME=team-name",
+		"BUILD_URL=http://example.com/teams/team-name/pipelines/pipeline-name/jobs/job-name/builds/6543",
 	)
 
 	stdin, err := outCmd.StdinPipe()

--- a/integration/out_test.go
+++ b/integration/out_test.go
@@ -195,7 +195,7 @@ func itWorksWithBranch(branchName string) {
 			})
 
 			It("commits with a descriptive message", func() {
-				log := exec.Command("git", "log", "--oneline", "-1", outResponse.Version.Ref)
+				log := exec.Command("git", "log", "-1", outResponse.Version.Ref)
 				log.Dir = bareGitRepo
 
 				session, err := gexec.Start(log, GinkgoWriter, GinkgoWriter)
@@ -203,7 +203,8 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("team-name/pipeline-name/job-name build 42 claiming: " + outResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("claiming: " + outResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("Build URL: http://example.com/teams/team-name/pipelines/pipeline-name/jobs/job-name/builds/6543"))
 			})
 		})
 
@@ -258,11 +259,11 @@ func itWorksWithBranch(branchName string) {
 			It("retries until a lock can be claimed", func() {
 				Consistently(session, 2*time.Second).ShouldNot(gexec.Exit(0))
 
-				releaseLock := exec.Command("bash", "-e", "-c", fmt.Sprint(`
+				releaseLock := exec.Command("bash", "-e", "-c", `
 				git mv lock-pool/claimed/some-lock lock-pool/unclaimed/some-lock
 				git commit -am "unclaiming some-lock"
 				git push
-			`))
+			`)
 
 				releaseLock.Dir = claimAllLocksDir
 
@@ -335,7 +336,7 @@ func itWorksWithBranch(branchName string) {
 			})
 
 			It("commits with a descriptive message", func() {
-				log := exec.Command("git", "log", "--oneline", "-1", outResponse.Version.Ref)
+				log := exec.Command("git", "log", "-1", outResponse.Version.Ref)
 				log.Dir = bareGitRepo
 
 				session, err := gexec.Start(log, GinkgoWriter, GinkgoWriter)
@@ -343,7 +344,8 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("team-name/pipeline-name/job-name build 42 claiming: some-lock"))
+				Ω(session).Should(gbytes.Say("claiming: some-lock"))
+				Ω(session).Should(gbytes.Say("Build URL: http://example.com/teams/team-name/pipelines/pipeline-name/jobs/job-name/builds/6543"))
 			})
 
 			Context("when the specific lock has already been claimed", func() {
@@ -501,7 +503,7 @@ func itWorksWithBranch(branchName string) {
 			})
 
 			It("commits with a descriptive message", func() {
-				log := exec.Command("git", "log", "--oneline", "-1", outRemoveResponse.Version.Ref)
+				log := exec.Command("git", "log", "-1", outRemoveResponse.Version.Ref)
 				log.Dir = bareGitRepo
 
 				session, err := gexec.Start(log, GinkgoWriter, GinkgoWriter)
@@ -509,7 +511,8 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("team-name/pipeline-name/job-name build 42 removing: " + outRemoveResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("removing: " + outRemoveResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("Build URL: http://example.com/teams/team-name/pipelines/pipeline-name/jobs/job-name/builds/6543"))
 			})
 		})
 
@@ -622,7 +625,7 @@ func itWorksWithBranch(branchName string) {
 			})
 
 			It("commits with a descriptive message", func() {
-				log := exec.Command("git", "log", "--oneline", "-1", outReleaseResponse.Version.Ref)
+				log := exec.Command("git", "log", "-1", outReleaseResponse.Version.Ref)
 				log.Dir = bareGitRepo
 
 				session, err := gexec.Start(log, GinkgoWriter, GinkgoWriter)
@@ -630,7 +633,8 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("team-name/pipeline-name/job-name build 42 unclaiming: " + outReleaseResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("unclaiming: " + outReleaseResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("Build URL: http://example.com/teams/team-name/pipelines/pipeline-name/jobs/job-name/builds/6543"))
 			})
 		})
 
@@ -698,7 +702,7 @@ func itWorksWithBranch(branchName string) {
 			})
 
 			It("commits with a descriptive message", func() {
-				log := exec.Command("git", "log", "--oneline", "-1", outResponse.Version.Ref)
+				log := exec.Command("git", "log", "-1", outResponse.Version.Ref)
 				log.Dir = bareGitRepo
 
 				session, err := gexec.Start(log, GinkgoWriter, GinkgoWriter)
@@ -706,7 +710,8 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("team-name/pipeline-name/job-name build 42 adding unclaimed: " + outResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("adding unclaimed: " + outResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("Build URL: http://example.com/teams/team-name/pipelines/pipeline-name/jobs/job-name/builds/6543"))
 			})
 		})
 
@@ -774,7 +779,7 @@ func itWorksWithBranch(branchName string) {
 			})
 
 			It("commits with a descriptive message", func() {
-				log := exec.Command("git", "log", "--oneline", "-1", outResponse.Version.Ref)
+				log := exec.Command("git", "log", "-1", outResponse.Version.Ref)
 				log.Dir = bareGitRepo
 
 				session, err := gexec.Start(log, GinkgoWriter, GinkgoWriter)
@@ -782,7 +787,8 @@ func itWorksWithBranch(branchName string) {
 
 				<-session.Exited
 
-				Ω(session).Should(gbytes.Say("team-name/pipeline-name/job-name build 42 adding claimed: " + outResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("adding claimed: " + outResponse.Metadata[0].Value))
+				Ω(session).Should(gbytes.Say("Build URL: http://example.com/teams/team-name/pipelines/pipeline-name/jobs/job-name/builds/6543"))
 			})
 		})
 
@@ -862,7 +868,7 @@ func itWorksWithBranch(branchName string) {
 				})
 
 				It("commits with a descriptive message", func() {
-					log := exec.Command("git", "log", "--oneline", "-1", outResponse.Version.Ref)
+					log := exec.Command("git", "log", "-1", outResponse.Version.Ref)
 					log.Dir = bareGitRepo
 
 					session, err := gexec.Start(log, GinkgoWriter, GinkgoWriter)
@@ -870,7 +876,8 @@ func itWorksWithBranch(branchName string) {
 
 					<-session.Exited
 
-					Ω(session).Should(gbytes.Say("team-name/pipeline-name/job-name build 42 adding unclaimed: " + outResponse.Metadata[0].Value))
+					Ω(session).Should(gbytes.Say("adding unclaimed: " + outResponse.Metadata[0].Value))
+					Ω(session).Should(gbytes.Say("Build URL: http://example.com/teams/team-name/pipelines/pipeline-name/jobs/job-name/builds/6543"))
 				})
 			})
 
@@ -975,7 +982,7 @@ func itWorksWithBranch(branchName string) {
 				})
 
 				It("commits with a descriptive message", func() {
-					log := exec.Command("git", "log", "--oneline", "-1", outResponse.Version.Ref)
+					log := exec.Command("git", "log", "-1", outResponse.Version.Ref)
 					log.Dir = bareGitRepo
 
 					session, err := gexec.Start(log, GinkgoWriter, GinkgoWriter)
@@ -983,7 +990,8 @@ func itWorksWithBranch(branchName string) {
 
 					<-session.Exited
 
-					Ω(session).Should(gbytes.Say("team-name/pipeline-name/job-name build 42 updating: " + outResponse.Metadata[0].Value))
+					Ω(session).Should(gbytes.Say("updating: " + outResponse.Metadata[0].Value))
+					Ω(session).Should(gbytes.Say("Build URL: http://example.com/teams/team-name/pipelines/pipeline-name/jobs/job-name/builds/6543"))
 				})
 			})
 		})

--- a/out/git_lock_handler.go
+++ b/out/git_lock_handler.go
@@ -42,7 +42,7 @@ func (glh *GitLockHandler) ClaimLock(lockName string) (string, error) {
 		return "", err
 	}
 
-	commitMessage := fmt.Sprintf(glh.messagePrefix()+"claiming: %s", lockName)
+	commitMessage := fmt.Sprintf("claiming: %s\n%s", lockName, glh.buildUrl())
 	_, err = glh.git("commit", "-m", commitMessage)
 	if err != nil {
 		return "", err
@@ -64,7 +64,7 @@ func (glh *GitLockHandler) RemoveLock(lockName string) (string, error) {
 		return "", err
 	}
 
-	_, err = glh.git("commit", "-m", glh.messagePrefix()+fmt.Sprintf("removing: %s", lockName))
+	_, err = glh.git("commit", "-m", fmt.Sprintf("removing: %s\n%s", lockName, glh.buildUrl()))
 	if err != nil {
 		return "", err
 	}
@@ -85,7 +85,7 @@ func (glh *GitLockHandler) UnclaimLock(lockName string) (string, error) {
 		return "", err
 	}
 
-	_, err = glh.git("commit", "-m", glh.messagePrefix()+fmt.Sprintf("unclaiming: %s", lockName))
+	_, err = glh.git("commit", "-m", fmt.Sprintf("unclaiming: %s\n%s", lockName, glh.buildUrl()))
 	if err != nil {
 		return "", err
 	}
@@ -133,7 +133,7 @@ func (glh *GitLockHandler) AddLock(lock string, contents []byte, initiallyClaime
 		return "", err
 	}
 
-	commitMessage := glh.messagePrefix() + fmt.Sprintf("adding %s: %s", claimedness, lock)
+	commitMessage := fmt.Sprintf("adding %s: %s\n%s", claimedness, lock, glh.buildUrl())
 	_, err = glh.git("commit", lockPath, "-m", commitMessage)
 	if err != nil {
 		return "", err
@@ -178,7 +178,7 @@ func (glh *GitLockHandler) UpdateLock(lockName string, contents []byte) (string,
 		return "", err
 	}
 
-	commitMessage := glh.messagePrefix() + fmt.Sprintf("%s: %s", operation, lockName)
+	commitMessage := fmt.Sprintf("%s: %s\n%s", operation, lockName, glh.buildUrl())
 	_, err = glh.git("commit", lockPath, "-m", commitMessage)
 	if err != nil {
 		return "", err
@@ -298,7 +298,7 @@ func (glh *GitLockHandler) GrabAvailableLock() (string, string, error) {
 		return "", "", err
 	}
 
-	commitMessage := fmt.Sprintf(glh.messagePrefix()+"claiming: %s", name)
+	commitMessage := fmt.Sprintf("claiming: %s\n%s", name, glh.buildUrl())
 	_, err = glh.git("commit", "-m", commitMessage)
 	if err != nil {
 		return "", "", err
@@ -345,22 +345,7 @@ func (glh *GitLockHandler) git(args ...string) ([]byte, error) {
 	return cmd.CombinedOutput()
 }
 
-func (glh *GitLockHandler) messagePrefix() string {
-	buildID := os.Getenv("BUILD_ID")
-	buildName := os.Getenv("BUILD_NAME")
-	jobName := os.Getenv("BUILD_JOB_NAME")
-	pipelineName := os.Getenv("BUILD_PIPELINE_NAME")
-	teamName := os.Getenv("BUILD_TEAM_NAME")
-	instanceVars := os.Getenv("BUILD_PIPELINE_INSTANCE_VARS")
-
-	if buildName != "" && jobName != "" && pipelineName != "" && teamName != "" {
-		if instanceVars != "" {
-			return fmt.Sprintf("%s/%s/%s/%s build %s ", teamName, pipelineName, instanceVars, jobName, buildName)
-		}
-		return fmt.Sprintf("%s/%s/%s build %s ", teamName, pipelineName, jobName, buildName)
-	} else if buildID != "" {
-		return fmt.Sprintf("one-off build %s ", buildID)
-	}
-
-	return ""
+func (glh *GitLockHandler) buildUrl() string {
+	buildUrl := os.Getenv("BUILD_URL")
+	return fmt.Sprintf("Build URL: %s ", buildUrl)
 }

--- a/out/out_request.go
+++ b/out/out_request.go
@@ -22,7 +22,7 @@ type Source struct {
 }
 
 func (s *Source) UnmarshalJSON(b []byte) error {
-	var inputData map[string]interface{}
+	var inputData map[string]any
 	err := json.NewDecoder(bytes.NewReader(b)).Decode(&inputData)
 	if err != nil {
 		return err


### PR DESCRIPTION
Closes #14 - Almost 10 years later since the issue was opened!!

Replacing the logic we had previously of parsing all the other `BUILD_*` env vars. `BUILD_URL` creates the correct URL for regular and instanced pipelines, and one-off builds. Should make debugging any pool locking issues much easier.