### PR TITLE
log errors from git commands to Stderr

### DIFF
--- a/out/fakes/fake_lock_handler.go
+++ b/out/fakes/fake_lock_handler.go
@@ -23,16 +23,16 @@ type FakeLockHandler struct {
 		result1 string
 		result2 error
 	}
-	BroadcastLockPoolStub        func() ([]byte, error)
+	BroadcastLockPoolStub        func() (string, error)
 	broadcastLockPoolMutex       sync.RWMutex
 	broadcastLockPoolArgsForCall []struct {
 	}
 	broadcastLockPoolReturns struct {
-		result1 []byte
+		result1 string
 		result2 error
 	}
 	broadcastLockPoolReturnsOnCall map[int]struct {
-		result1 []byte
+		result1 string
 		result2 error
 	}
 	CheckLockStub        func(string) (string, error)
@@ -223,7 +223,7 @@ func (fake *FakeLockHandler) AddLockReturnsOnCall(i int, result1 string, result2
 	}{result1, result2}
 }
 
-func (fake *FakeLockHandler) BroadcastLockPool() ([]byte, error) {
+func (fake *FakeLockHandler) BroadcastLockPool() (string, error) {
 	fake.broadcastLockPoolMutex.Lock()
 	ret, specificReturn := fake.broadcastLockPoolReturnsOnCall[len(fake.broadcastLockPoolArgsForCall)]
 	fake.broadcastLockPoolArgsForCall = append(fake.broadcastLockPoolArgsForCall, struct {
@@ -247,34 +247,34 @@ func (fake *FakeLockHandler) BroadcastLockPoolCallCount() int {
 	return len(fake.broadcastLockPoolArgsForCall)
 }
 
-func (fake *FakeLockHandler) BroadcastLockPoolCalls(stub func() ([]byte, error)) {
+func (fake *FakeLockHandler) BroadcastLockPoolCalls(stub func() (string, error)) {
 	fake.broadcastLockPoolMutex.Lock()
 	defer fake.broadcastLockPoolMutex.Unlock()
 	fake.BroadcastLockPoolStub = stub
 }
 
-func (fake *FakeLockHandler) BroadcastLockPoolReturns(result1 []byte, result2 error) {
+func (fake *FakeLockHandler) BroadcastLockPoolReturns(result1 string, result2 error) {
 	fake.broadcastLockPoolMutex.Lock()
 	defer fake.broadcastLockPoolMutex.Unlock()
 	fake.BroadcastLockPoolStub = nil
 	fake.broadcastLockPoolReturns = struct {
-		result1 []byte
+		result1 string
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeLockHandler) BroadcastLockPoolReturnsOnCall(i int, result1 []byte, result2 error) {
+func (fake *FakeLockHandler) BroadcastLockPoolReturnsOnCall(i int, result1 string, result2 error) {
 	fake.broadcastLockPoolMutex.Lock()
 	defer fake.broadcastLockPoolMutex.Unlock()
 	fake.BroadcastLockPoolStub = nil
 	if fake.broadcastLockPoolReturnsOnCall == nil {
 		fake.broadcastLockPoolReturnsOnCall = make(map[int]struct {
-			result1 []byte
+			result1 string
 			result2 error
 		})
 	}
 	fake.broadcastLockPoolReturnsOnCall[i] = struct {
-		result1 []byte
+		result1 string
 		result2 error
 	}{result1, result2}
 }

--- a/out/git_lock_handler.go
+++ b/out/git_lock_handler.go
@@ -14,6 +14,8 @@ var ErrNoLocksAvailable = errors.New("no locks to claim")
 var ErrLockConflict = errors.New("pool state out of date")
 var ErrLockActive = errors.New("lock found")
 
+var _ LockHandler = (*GitLockHandler)(nil)
+
 type GitLockHandler struct {
 	Source Source
 
@@ -37,75 +39,86 @@ func (glh *GitLockHandler) ClaimLock(lockName string) (string, error) {
 		return "", ErrNoLocksAvailable
 	}
 
-	_, err = glh.git("mv", filepath.Join(glh.Source.Pool, "unclaimed", lockName), filepath.Join(glh.Source.Pool, "claimed", lockName))
+	output, err := glh.git("mv", filepath.Join(glh.Source.Pool, "unclaimed", lockName), filepath.Join(glh.Source.Pool, "claimed", lockName))
 	if err != nil {
+		fmt.Fprintln(os.Stderr, output)
 		return "", err
 	}
 
 	commitMessage := fmt.Sprintf("claiming: %s\n%s", lockName, glh.buildUrl())
-	_, err = glh.git("commit", "-m", commitMessage)
+	output, err = glh.git("commit", "-m", commitMessage)
 	if err != nil {
+		fmt.Fprintln(os.Stderr, output)
 		return "", err
 	}
 
 	ref, err := glh.git("rev-parse", "HEAD")
 	if err != nil {
+		fmt.Fprintln(os.Stderr, ref)
 		return "", err
 	}
 
-	return string(ref), nil
+	return ref, nil
 }
 
 func (glh *GitLockHandler) RemoveLock(lockName string) (string, error) {
 	pool := filepath.Join(glh.dir, glh.Source.Pool)
 
-	_, err := glh.git("rm", filepath.Join(pool, "claimed", lockName))
+	output, err := glh.git("rm", filepath.Join(pool, "claimed", lockName))
 	if err != nil {
+		fmt.Fprintln(os.Stderr, output)
 		return "", err
 	}
 
-	_, err = glh.git("commit", "-m", fmt.Sprintf("removing: %s\n%s", lockName, glh.buildUrl()))
+	output, err = glh.git("commit", "-m", fmt.Sprintf("removing: %s\n%s", lockName, glh.buildUrl()))
 	if err != nil {
+		fmt.Fprintln(os.Stderr, output)
 		return "", err
 	}
 
 	ref, err := glh.git("rev-parse", "HEAD")
 	if err != nil {
+		fmt.Fprintln(os.Stderr, ref)
 		return "", err
 	}
 
-	return string(ref), nil
+	return ref, nil
 }
 
 func (glh *GitLockHandler) UnclaimLock(lockName string) (string, error) {
 	pool := filepath.Join(glh.dir, glh.Source.Pool)
 
-	_, err := glh.git("mv", filepath.Join(pool, "claimed", lockName), filepath.Join(pool, "unclaimed", lockName))
+	output, err := glh.git("mv", filepath.Join(pool, "claimed", lockName), filepath.Join(pool, "unclaimed", lockName))
 	if err != nil {
+		fmt.Fprintln(os.Stderr, output)
 		return "", err
 	}
 
-	_, err = glh.git("commit", "-m", fmt.Sprintf("unclaiming: %s\n%s", lockName, glh.buildUrl()))
+	output, err = glh.git("commit", "-m", fmt.Sprintf("unclaiming: %s\n%s", lockName, glh.buildUrl()))
 	if err != nil {
+		fmt.Fprintln(os.Stderr, output)
 		return "", err
 	}
 
 	ref, err := glh.git("rev-parse", "HEAD")
 	if err != nil {
+		fmt.Fprintln(os.Stderr, ref)
 		return "", err
 	}
 
-	return string(ref), nil
+	return ref, nil
 }
 
 func (glh *GitLockHandler) ResetLock() error {
-	_, err := glh.git("fetch", "origin", glh.Source.Branch)
+	output, err := glh.git("fetch", "origin", glh.Source.Branch)
 	if err != nil {
+		fmt.Fprintln(os.Stderr, output)
 		return err
 	}
 
-	_, err = glh.git("reset", "--hard", "origin/"+glh.Source.Branch)
+	output, err = glh.git("reset", "--hard", "origin/"+glh.Source.Branch)
 	if err != nil {
+		fmt.Fprintln(os.Stderr, output)
 		return err
 	}
 
@@ -128,19 +141,22 @@ func (glh *GitLockHandler) AddLock(lock string, contents []byte, initiallyClaime
 		return "", err
 	}
 
-	_, err = glh.git("add", lockPath)
+	output, err := glh.git("add", lockPath)
 	if err != nil {
+		fmt.Fprintln(os.Stderr, output)
 		return "", err
 	}
 
 	commitMessage := fmt.Sprintf("adding %s: %s\n%s", claimedness, lock, glh.buildUrl())
-	_, err = glh.git("commit", lockPath, "-m", commitMessage)
+	output, err = glh.git("commit", lockPath, "-m", commitMessage)
 	if err != nil {
+		fmt.Fprintln(os.Stderr, output)
 		return "", err
 	}
 
 	ref, err := glh.git("rev-parse", "HEAD")
 	if err != nil {
+		fmt.Fprintln(os.Stderr, ref)
 		return "", err
 	}
 
@@ -173,23 +189,26 @@ func (glh *GitLockHandler) UpdateLock(lockName string, contents []byte) (string,
 		return "", err
 	}
 
-	_, err = glh.git("add", lockPath)
+	output, err := glh.git("add", lockPath)
 	if err != nil {
+		fmt.Fprintln(os.Stderr, output)
 		return "", err
 	}
 
 	commitMessage := fmt.Sprintf("%s: %s\n%s", operation, lockName, glh.buildUrl())
-	_, err = glh.git("commit", lockPath, "-m", commitMessage)
+	output, err = glh.git("commit", lockPath, "-m", commitMessage)
 	if err != nil {
+		fmt.Fprintln(os.Stderr, output)
 		return "", err
 	}
 
 	ref, err := glh.git("rev-parse", "HEAD")
 	if err != nil {
+		fmt.Fprintln(os.Stderr, ref)
 		return "", err
 	}
 
-	return string(ref), nil
+	return ref, nil
 }
 
 func (glh *GitLockHandler) CheckLock(lockName string) (string, error) {
@@ -201,13 +220,15 @@ func (glh *GitLockHandler) CheckLock(lockName string) (string, error) {
 		return "", ErrLockActive
 	}
 
-	_, err = glh.git("pull", "origin", glh.Source.Branch)
+	output, err := glh.git("pull", "origin", glh.Source.Branch)
 	if err != nil {
+		fmt.Fprintln(os.Stderr, output)
 		return "", err
 	}
 
 	ref, err := glh.git("rev-parse", "HEAD")
 	if err != nil {
+		fmt.Fprintln(os.Stderr, ref)
 		return "", err
 	}
 
@@ -223,13 +244,15 @@ func (glh *GitLockHandler) CheckUnclaimedLock(lockName string) (string, error) {
 		return "", ErrLockActive
 	}
 
-	_, err = glh.git("pull", "origin", glh.Source.Branch)
+	output, err := glh.git("pull", "origin", glh.Source.Branch)
 	if err != nil {
+		fmt.Fprintln(os.Stderr, output)
 		return "", err
 	}
 
 	ref, err := glh.git("rev-parse", "HEAD")
 	if err != nil {
+		fmt.Fprintln(os.Stderr, ref)
 		return "", err
 	}
 
@@ -244,7 +267,7 @@ func (glh *GitLockHandler) Setup() error {
 		return err
 	}
 
-	cmd := exec.Command("git", "clone", "--branch", glh.Source.Branch, glh.Source.URI, glh.dir)
+	cmd := exec.Command("git", "clone", "--single-branch", "--branch", glh.Source.Branch, glh.Source.URI, glh.dir)
 	err = cmd.Run()
 	if err != nil {
 		return err
@@ -253,8 +276,9 @@ func (glh *GitLockHandler) Setup() error {
 	_, err = glh.git("config", "user.name")
 	if err != nil {
 		// hardcode git user.name if not already set in git_config
-		_, err = glh.git("config", "user.name", "CI Pool Resource")
+		output, err := glh.git("config", "user.name", "CI Pool Resource")
 		if err != nil {
+			fmt.Fprintln(os.Stderr, output)
 			return err
 		}
 	}
@@ -262,8 +286,9 @@ func (glh *GitLockHandler) Setup() error {
 	_, err = glh.git("config", "user.email")
 	if err != nil {
 		// hardcode git user.email if not already set in git_config
-		_, err = glh.git("config", "user.email", "ci-pool@localhost")
+		output, err := glh.git("config", "user.email", "ci-pool@localhost")
 		if err != nil {
+			fmt.Fprintln(os.Stderr, output)
 			return err
 		}
 	}
@@ -293,29 +318,32 @@ func (glh *GitLockHandler) GrabAvailableLock() (string, string, error) {
 	index := rand.Int() % len(files)
 	name := filepath.Base(files[index].Name())
 
-	_, err = glh.git("mv", filepath.Join(glh.Source.Pool, "unclaimed", name), filepath.Join(glh.Source.Pool, "claimed", name))
+	output, err := glh.git("mv", filepath.Join(glh.Source.Pool, "unclaimed", name), filepath.Join(glh.Source.Pool, "claimed", name))
 	if err != nil {
+		fmt.Fprintln(os.Stderr, output)
 		return "", "", err
 	}
 
 	commitMessage := fmt.Sprintf("claiming: %s\n%s", name, glh.buildUrl())
-	_, err = glh.git("commit", "-m", commitMessage)
+	output, err = glh.git("commit", "-m", commitMessage)
 	if err != nil {
+		fmt.Fprintln(os.Stderr, output)
 		return "", "", err
 	}
 
 	ref, err := glh.git("rev-parse", "HEAD")
 	if err != nil {
+		fmt.Fprintln(os.Stderr, ref)
 		return "", "", err
 	}
 
 	return name, string(ref), nil
 }
 
-func (glh *GitLockHandler) BroadcastLockPool() ([]byte, error) {
+func (glh *GitLockHandler) BroadcastLockPool() (string, error) {
 	// validate if we're doing check only
 	if glh.checkOnly {
-		return []byte{}, nil
+		return "", nil
 	}
 
 	contents, err := glh.git("push", "origin", "HEAD:"+glh.Source.Branch)
@@ -324,25 +352,26 @@ func (glh *GitLockHandler) BroadcastLockPool() ([]byte, error) {
 	// a commit in the same second acquiring the same lock
 	//
 	// we need to stop and try again
-	if strings.Contains(string(contents), falsePushString) {
+	if strings.Contains(contents, falsePushString) {
 		return contents, ErrLockConflict
 	}
 
-	if strings.Contains(string(contents), pushRejectedString) {
+	if strings.Contains(contents, pushRejectedString) {
 		return contents, ErrLockConflict
 	}
 
-	if strings.Contains(string(contents), pushRemoteRejectedString) {
+	if strings.Contains(contents, pushRemoteRejectedString) {
 		return contents, ErrLockConflict
 	}
 
 	return contents, err
 }
 
-func (glh *GitLockHandler) git(args ...string) ([]byte, error) {
+func (glh *GitLockHandler) git(args ...string) (string, error) {
 	arguments := append([]string{"-C", glh.dir}, args...)
 	cmd := exec.Command("git", arguments...)
-	return cmd.CombinedOutput()
+	s, err := cmd.CombinedOutput()
+	return string(s), err
 }
 
 func (glh *GitLockHandler) buildUrl() string {

--- a/out/lock_pool.go
+++ b/out/lock_pool.go
@@ -43,7 +43,7 @@ type LockHandler interface {
 	CheckUnclaimedLock(lock string) (version string, err error)
 
 	Setup() error
-	BroadcastLockPool() ([]byte, error)
+	BroadcastLockPool() (string, error)
 	ResetLock() error
 }
 
@@ -70,6 +70,11 @@ func (lp *LockPool) ClaimLock(lock string) (Version, error) {
 
 		return false, nil
 	})
+
+	if err != nil {
+		return Version{}, err
+	}
+
 	fmt.Fprintf(lp.Output, "\nclaimed!\n")
 
 	return Version{
@@ -106,6 +111,7 @@ func (lp *LockPool) AcquireLock() (string, Version, error) {
 	if err != nil {
 		return "", Version{}, err
 	}
+
 	fmt.Fprintf(lp.Output, "\nacquired!\n")
 
 	return lock, Version{
@@ -263,6 +269,7 @@ func (lp *LockPool) UpdateLock(inDir string) (string, Version, error) {
 	if err != nil {
 		return "", Version{}, err
 	}
+
 	fmt.Fprintf(lp.Output, "\nupdated!\n")
 
 	return lockName, Version{
@@ -347,21 +354,20 @@ func (lp *LockPool) CheckUnclaimedLock(inDir string) (string, Version, error) {
 func (lp *LockPool) performRobustAction(action func() (bool, error)) error {
 	err := lp.LockHandler.Setup()
 	if err != nil {
-		return err
+		return fmt.Errorf("setup: %w", err)
 	}
 
-	var gitOutput []byte
 	unexpectedErrorRetry := 0
 	for unexpectedErrorRetry < 5 {
 		err = lp.LockHandler.ResetLock()
 		if err != nil {
-			return err
+			return fmt.Errorf("reset lock: %w", err)
 		}
 
 		retry, err := action()
 
 		if err != nil {
-			return err
+			return fmt.Errorf("action: %w", err)
 		}
 
 		if retry {
@@ -369,7 +375,7 @@ func (lp *LockPool) performRobustAction(action func() (bool, error)) error {
 			continue
 		}
 
-		gitOutput, err = lp.LockHandler.BroadcastLockPool()
+		gitOutput, err := lp.LockHandler.BroadcastLockPool()
 
 		if err == ErrLockConflict {
 			fmt.Fprint(lp.Output, ".")

--- a/out/lock_pool_test.go
+++ b/out/lock_pool_test.go
@@ -31,13 +31,13 @@ var _ = Describe("Lock Pool", func() {
 				BeforeEach(func() {
 					called := false
 
-					fakeLockHandler.BroadcastLockPoolStub = func() ([]byte, error) {
+					fakeLockHandler.BroadcastLockPoolStub = func() (string, error) {
 						// succeed on second call
 						if !called {
 							called = true
-							return nil, errors.New("disaster")
+							return "", errors.New("disaster")
 						} else {
-							return nil, nil
+							return "", nil
 						}
 					}
 				})
@@ -53,7 +53,7 @@ var _ = Describe("Lock Pool", func() {
 
 				Context("more than 5 times", func() {
 					BeforeEach(func() {
-						fakeLockHandler.BroadcastLockPoolReturns([]byte("some git message"), errors.New("disaster"))
+						fakeLockHandler.BroadcastLockPoolReturns("some git message", errors.New("disaster"))
 					})
 
 					It("shows the underlying git error", func() {
@@ -71,13 +71,13 @@ var _ = Describe("Lock Pool", func() {
 				BeforeEach(func() {
 					called := false
 
-					fakeLockHandler.BroadcastLockPoolStub = func() ([]byte, error) {
+					fakeLockHandler.BroadcastLockPoolStub = func() (string, error) {
 						// succeed on second call
 						if !called {
 							called = true
-							return nil, out.ErrLockConflict
+							return "", out.ErrLockConflict
 						} else {
-							return nil, nil
+							return "", nil
 						}
 					}
 				})


### PR DESCRIPTION
makes it easier for when user reports errors. Currently we just get the exit status of the git command, which alone is not useful.

Also added `--single-branch` to the `git clone` command in the Setup() func.

Motivation is to get better info for #72